### PR TITLE
Small fix for the issues index sidebar

### DIFF
--- a/app/views/shared/_view_issues_sidebar.html.erb
+++ b/app/views/shared/_view_issues_sidebar.html.erb
@@ -1,12 +1,12 @@
 <div>
     <% if sprints && sprints.size > 0 %>
         <h3><%= l(:backlogs_sprints) %></h3>
-        <% sprints.each do |sprint| %>
-            <%= link_to(sprint.name, {
+        <% sprints.each do |sp| %>
+            <%= link_to(sp.name, {
                     :controller => 'rb_queries',
                     :action => 'show',
                     :project_id => project.id,
-                    :sprint_id => sprint.id
+                    :sprint_id => sp.id
                     }) %><br/>
         <% end %>
     <% end %>


### PR DESCRIPTION
Hi,

I was wondering why on the issues index sidebar, it was always the last open sprint that was displayed in there. Looking at the code, I realized that it should have been the sprint corresponding to the filtered target version but didn't work either.

Finally, I realized that the sprint variable is overwritten in the template within the loop that displays the list of sprints, so that's why the sprint and burndown displayed on that sidebar is always the last one. That commit simply fixes this by renaming the sprint variable to sp inside the loop.

Maxime
