### PR TITLE
fixed a bug in master backlog

### DIFF
--- a/app/controllers/rb_application_controller.rb
+++ b/app/controllers/rb_application_controller.rb
@@ -11,12 +11,12 @@ class RbApplicationController < ApplicationController
   def load_context
 
     # load a shared sprint in the context of a given project
-    if params[:project_id] && params[:sprint_id]
+    if params[:project_id] && params[:sprint_id].present?
       @project = Project.find(params[:project_id])
       @sprint = @project.sprint(params[:sprint_id])
 
     # load a sprint in the context of the project that owns it
-    elsif params[:sprint_id]
+    elsif params[:sprint_id].present?
       #@sprint = Sprint.find(params[:sprint_id])
       #@project = @sprint.project
       raise "It's best to always explicitly load the project now we have shared sprints"


### PR DESCRIPTION
When I moved a user story from sprint to backlog, I got an error.
Looks params[:sprint_id] can be ""(empty string) in master_backlogs screen and it raises an exception. 

I'm not sure why it doesn't happen in your demo site.. We're using rails 2.3.5 + redmine 1.0.0
