### PR TITLE
500 Occurs When You're Trying to View the Sidebar and are not in a Project

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -4,7 +4,6 @@ module BacklogsPlugin
       # this ought to be view_issues_sidebar_queries_bottom, but
       # the entire queries toolbar is disabled if you don't have
       # custom queries
-
       def view_issues_sidebar_planning_bottom(context={ })
         locals = {}
         locals[:sprints] = context[:project] ? Sprint.open_sprints(context[:project]) : []
@@ -12,7 +11,7 @@ module BacklogsPlugin
         locals[:sprint] = nil
         locals[:webcal] = (context[:request].ssl? ? 'webcals' : 'webcal')
 
-        return '' if locals[:project].blank? || ! locals[:project].module_enabled?('backlogs')
+        return '' unless locals[:project] && locals[:project].module_enabled?('backlogs')
 
         user = User.find_by_id(context[:request].session[:user_id])
         locals[:key] = user ? user.api_key : nil


### PR DESCRIPTION
If you're running an install with multiple projects when you view "My Page" or other pages that aren't associated with any project, you get a 500 when trying to view one:

```
ActionView::TemplateError (undefined method `module_enabled?' for nil:NilClass) on line #14 of app/views/issues/_sidebar.rhtml:
...
```

This actually happens in the hook. This pull request checks to see if you're on a project before checking if the module is enabled for a project.

Thanks,

Nathan
