### PR TITLE
Fix for broken task creation in redmine 1.1.x

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -13,7 +13,7 @@ class Task < Issue
     if Issue.const_defined? "SAFE_ATTRIBUTES"
       attribs = params.clone.delete_if {|k,v| !Task::SAFE_ATTRIBUTES.include?(k) }
     else
-      attribs = params.clone.delete_if {|k,v| !Task.safe_attributes.include?(k) }
+      attribs = params.clone.delete_if {|k,v| !Issue.new.safe_attribute_names.include?(k.to_s) }
     end
     attribs[:remaining_hours] = 0 if IssueStatus.find(params[:status_id]).is_closed?
     attribs['author_id'] = user_id
@@ -60,7 +60,7 @@ class Task < Issue
     if Issue.const_defined? "SAFE_ATTRIBUTES"
       attribs = params.clone.delete_if {|k,v| !Task::SAFE_ATTRIBUTES.include?(k) }
     else
-      attribs = params.clone.delete_if {|k,v| !Task.safe_attributes.include?(k) }
+      attribs = params.clone.delete_if {|k,v| !Issue.new.safe_attribute_names.include?(k.to_s) }
     end
     attribs[:remaining_hours] = 0 if IssueStatus.find(params[:status_id]).is_closed?
 
@@ -78,10 +78,10 @@ class Task < Issue
       false
     end
   end
-  
+
   def update_blocked_list(for_blocking)
     # Existing relationships not in for_blocking should be removed from the 'blocks' list
-    relations_from.find(:all, :conditions => "relation_type='blocks'").each{ |ir| 
+    relations_from.find(:all, :conditions => "relation_type='blocks'").each{ |ir|
       ir.destroy unless for_blocking.include?( ir[:issue_to_id] )
     }
 
@@ -95,7 +95,7 @@ class Task < Issue
     }
     reload
   end
-  
+
   def validate_blocks_list(list)
     if list.split(/\D+/).length==0
       errors.add :blocks, :error_must_have_comma_delimited_list
@@ -104,7 +104,7 @@ class Task < Issue
       true
     end
   end
-  
+
   # assumes the task is already under the same story as 'id'
   def move_after(id)
     id = nil if id.respond_to?('blank?') && id.blank?


### PR DESCRIPTION
Object.safe_attributes is not inheritable and doesn't return a list of method names.
The patch fixes the creation for redmine 1.1.x. 
