### PR TITLE
Fix backlogs menu helper

### DIFF
--- a/app/helpers/rb_master_backlogs_helper.rb
+++ b/app/helpers/rb_master_backlogs_helper.rb
@@ -21,7 +21,7 @@ module RbMasterBacklogsHelper
         <ul class="items">
     }
     items.each do |item|
-      item[:condition] = true if item[:condition].blank?
+      item[:condition] = true unless item.has_key?(:condition)
       if item[:condition] && ( (is_sprint && item[:for] == :sprint) ||
                                (!is_sprint && item[:for] == :product) ||
                                (item[:for] == :both) )


### PR DESCRIPTION
The `backlog_menu` method in `app/helpers/rb_master_backligs_helper.rb` is broken. It does not consider the `condition` parameter properly. Since `nil` and `false` are always `blank?`, the condition parameter is always set to `true`. This results in the `Burndown Chart` always being displayed in the sprint's dropdown menu.

The changes attached to this pull request fix the method, so that the condition parameter is properly used.

Thanks for taking a look into it.

Gregor
