### PR TITLE
Fix installation on redmine 1.1.3

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -27,7 +27,7 @@ namespace :redmine do
 
         platform = :redmine if line.match(/^== Redmine changelog$/)
         
-        m = line.match(/^== 2011-03-07 v([.0-9]+)$/)
+        m = line.match(/^== [0-9]{4}-[0-9]{2}-[0-9]{2} v([.0-9]+)$/)
         version = m[1] if m
       end
 


### PR DESCRIPTION
Installer checks for redmine version by looking at the changelog for a
particular date and parses out the version from the same line. The
broken code used to look for a particular date (probably corresponding
ot the previous release). I changed it to look at any YYYY-MM-DD string
so that it's future proof.
