### PR TITLE
Fix html errors in master_backlogs 

### DIFF
--- a/app/views/rb_master_backlogs/_backlog.html.erb
+++ b/app/views/rb_master_backlogs/_backlog.html.erb
@@ -8,7 +8,7 @@
       <div class="label"><%=l(:label_product_backlog).titleize %></div>
       <a class="add_new_story" href="#">New Story</a>
       <a class="add_new_sprint" href="#">New Sprint</a>
-      <a class="close_sprint" <%= link_to "Close completed Sprints", close_completed_project_versions_path(@project), :method => :put, :target => "_blank" %>
+      <%= link_to "Close completed Sprints", close_completed_project_versions_path(@project), :class => "close_sprint", :method => :put, :target => "_blank" %>
     <%- end %>
   </div>
   <ul class="stories">

--- a/app/views/rb_master_backlogs/show.html.erb
+++ b/app/views/rb_master_backlogs/show.html.erb
@@ -12,7 +12,7 @@
 <%- end %>
 
 <%- content_for :view_specific_links do %>
-  <a id="project_info">Info<a>
+  <a id="project_info">Info</a>
   <a id="disable_autorefresh">Disable Auto-refresh</a>
   <a id="refresh">Refresh</a>
 <%- end %>


### PR DESCRIPTION
Two obvious errors. One is a typo (missing </a> for info). Another is
incorrect way to add a CSS class to a link.
