### PR TITLE
Fixes #114. Dublicate-function with 'copy open'-option 

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -169,7 +169,7 @@ module BacklogsPlugin
             if action != 'none'
               case action
                 when 'open'
-                  tasks = story.tasks.select{|t| !t.closed?}
+                  tasks = story.tasks.select{|t| !t.reload.closed?}
                 when 'none'
                   tasks = []
                 when 'all'


### PR DESCRIPTION
Fixes #114. Dublicate-function with 'copy open'-option now only copies open issues in stead of all
