### PR TITLE
better way to handling enter/escape, #126

### DIFF
--- a/assets/javascripts/editable_inplace.js
+++ b/assets/javascripts/editable_inplace.js
@@ -2,9 +2,7 @@ RB.EditableInplace = RB.Object.create(RB.Model, {
 
   displayEditor: function(editor){
     this.$.addClass("editing");
-    editor.find(".editor").bind('keyup', this.handleKeyup).bind('keydown', this.handleKeydown).bind('keypress', this.handleKeypress);
-    this.isEnter = false;
-    this.isEscape = false;
+    editor.find(".editor").bind('keydown', this.handleKeydown).bind('keypress', this.handleKeypress);
   },
 
   getEditor: function(){
@@ -18,42 +16,27 @@ RB.EditableInplace = RB.Object.create(RB.Model, {
     return editor;
   },
 
-  handleKeydown: function(event) {
-    this.isEnter = (event.which == 13);
-    this.isEscape = (event.which == 27);
-    return true;
-  },
   handleKeypress: function(event) {
-    this.isEnter = this.isEnter && (event.which == 13);
-    this.isEscape = this.isEscape && (event.which == 27);
-    return true;
+    // handle keys on keypress instead of keyup, so IME will not fire enter.
+    // https://github.com/ether/pad/pull/168
+    if(event.which == 13){
+      j = $(this).parents('.model').first();
+      that = j.data('this');
+      that.saveEdits();
+    } else {
+      return true;
+    }
   },
-  handleKeyup: function(event) {
-    j = $(this).parents('.model').first();
-    that = j.data('this');
 
-    var isEnter = this.isEnter;
-    this.isEnter = false;
-    var isEscape = this.isEscape;
-    this.isEscape = false;
-
-    switch(event.which) {
-      case 13:
-        if (isEnter) { that.saveEdits();
-        } else {
-          return true;
-        }
-        break;
-
-      case 27:
-        if (isEscape) { that.cancelEdit();     // ESC
-        } else {
-            return true;
-        }
-        break;
-
-      default:
-        return true;
+  handleKeydown: function(event) {
+    // handle escape key on keydown, since it doesn't fire keypress on chrome/safari
+    // http://stackoverflow.com/questions/3901063/jquerys-keypress-doesnt-work-for-some-keys-in-chrome-how-to-work-around
+    if(event.which == 27){
+      j = $(this).parents('.model').first();
+      that = j.data('this');
+      that.cancelEdit();
+    } else {
+      return true;
     }
   }
 });


### PR DESCRIPTION
. catch enter key with keypress, so enter key during IME won't fired.
. catch escape key with keydown, since chrome/safari doesn't fire keypress on escape.
