### PR TITLE
Changed release snapshot to count all open stories in stead of only backlog stories

### DIFF
--- a/app/models/rb_release.rb
+++ b/app/models/rb_release.rb
@@ -100,7 +100,7 @@ class RbRelease < ActiveRecord::Base
     end
 
     def stories
-        return RbStory.product_backlog(@project)
+      return RbStory.stories_open(@project)
     end
 
     def burndown_days

--- a/app/models/rb_story.rb
+++ b/app/models/rb_story.rb
@@ -53,6 +53,19 @@ class RbStory < Issue
       return RbStory.backlog(sprint.project.id, sprint.id, options)
     end
 
+    def self.stories_open(project)
+      stories = []
+
+      RbStory.find(:all,
+            :order => RbStory::ORDER,
+            :conditions => ["project_id = ? AND tracker_id in (?) and is_closed = ?",project.id,RbStory.trackers,false],
+            :joins => :status).each_with_index {|story, i|
+        story.rank = i + 1
+        stories << story
+      }
+      return stories
+    end
+
     def self.create_and_position(params)
       attribs = params.select{|k,v| k != 'prev_id' and k != 'id' and RbStory.column_names.include? k }
       attribs = Hash[*attribs.flatten]

--- a/app/views/rb_releases/_form.html.erb
+++ b/app/views/rb_releases/_form.html.erb
@@ -13,7 +13,7 @@
   <p>
     <%= f.text_field :initial_story_points, :required => true %>
     <% if backlog_points %>
-      (current points in backlog: <%= backlog_points %>)
+      (<%= l(:current_open_story_points) %> <%= backlog_points %>)
     <% end %>
   </p>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -100,3 +100,4 @@ de:
   backlogs_product_backlog: Produkt Backlog
   remaining_hours: Verbleibende Stunden
   error_outro: Bitte beheben Sie die obigen Fehler bevor Sie erneut abschicken.
+  current_open_story_points: "Current open story points:"

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -112,3 +112,4 @@ en-GB:
   rb_task_cards_story_follows_tasks: Tasks followed by their story
   rb_task_cards_tasks_follow_story: Story followed by their tasks
   rb_task_cards_stories_then_tasks: First all stories, then all tasks
+  current_open_story_points: "Current open story points:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,6 +111,7 @@ en:
   field_number_of_snapshots: Saved point snapshots
   release_update_snapshot_today: Update story point snapshot for today
   release_create_snapshot_today: Save story point snapshot for today
+  current_open_story_points: "Current open story points:"
 
   # Version fields
   field_name: "Name"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -119,3 +119,4 @@ es:
   rb_label_copy_tasks_none: "None"
   rb_label_copy_tasks_all: "All"
   rb_label_copy_tasks_open: "Open"
+  current_open_story_points: "Current open story points:"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -84,3 +84,4 @@ fr:
   backlogs_product_backlog: Carnet de produit
   remaining_hours: heures restantes
   error_outro: "Veuillez corriger les erreurs ci-dessus avant de soumettre à nouveau."
+  current_open_story_points: "Current open story points:"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -108,3 +108,4 @@ nl:
   rb_task_cards_story_follows_tasks: Taken gevolgd door hun bijbehorende story
   rb_task_cards_tasks_follow_story: Story gevolg door de bijbehorende taken
   rb_task_cards_stories_then_tasks: Eerst alle stories, dan alle taken
+  current_open_story_points: "Current open story points:"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -86,3 +86,4 @@ pt-BR:
   backlogs_product_backlog: Product backlog
   remaining_hours: Horas restantes
   error_outro: Por favor corriga os erros antes de enviar novamente.
+  current_open_story_points: "Current open story points:"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -121,3 +121,4 @@ ru:
   rb_label_copy_tasks_none: "Нет (Не копировать задания)"
   rb_label_copy_tasks_all: "Все (Копировать все задания)"
   rb_label_copy_tasks_open: "Открыть"
+  current_open_story_points: "Current open story points:"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -217,3 +217,4 @@ zh:
     5Zyo5YaN5qyh5o+Q5Lqk5LmL5YmN77yM6K+35YWI5pu05q2j5Lul5LiK55qE
     6ZSZ6K+v44CC
 
+  current_open_story_points: "Current open story points:"


### PR DESCRIPTION
This changes the initial and snapshot story points to open stories in stead of only stories in product backlog. It seems to early to write off the story points when they are removed from the product backlog, but maybe not even on a active sprint yet. It should only affect the Release-pages.

Best regards,
Bo
