### PR TITLE
burndown: fixed able to show highlight.

### DIFF
--- a/app/views/rb_burndown_charts/_burndown.html.erb
+++ b/app/views/rb_burndown_charts/_burndown.html.erb
@@ -29,7 +29,7 @@
               :yaxis => {:min => 0, :max => burndown[:max_hours], :tickOptions => {:formatString => '%d'}},
               :y2axis => {:min => 0, :max => burndown[:max_points], :tickOptions => {:formatString => '%d'}}
           },
-          :highlighter => { :tooltipAxes => 'y', :formatString => '%s' }
+          :highlighter => { :tooltipAxes => 'y', :formatString => '%s', :show => true }
         }
       }
   %>


### PR DESCRIPTION
in my local redmine backlogs(master).
burndown don't show highlight.

So I fixed.
