### PR TITLE
Weaken story list's color contrast

### DIFF
--- a/assets/stylesheets/master_backlog.css
+++ b/assets/stylesheets/master_backlog.css
@@ -255,7 +255,7 @@
   background-position:center;
 }
 #backlogs_container .stories .story:nth-child(even){
-  background-color:#DEDED5;
+  background-color:#EEEEE5;
 }
 #backlogs_container .stories .story:hover{
   background-color:rgb(254,248,168);


### PR DESCRIPTION
I feel backlog list's color contrast is too strong.So weaken it.
