### PR TITLE
Story points can edit with dropdown

### DIFF
--- a/app/views/rb_stories/_helpers.html.erb
+++ b/app/views/rb_stories/_helpers.html.erb
@@ -5,6 +5,14 @@
   <%- end %>
 </select>
 
+<%- unless Setting.plugin_redmine_backlogs[:story_points].blank? -%>
+<select class="story_points helper" id="story_points_options">
+	<%- (['']+Setting.plugin_redmine_backlogs[:story_points].split(/,/)).each do |point| %>
+	<option value="<%=h point %>"><%=h point %></option>
+	<%- end %>
+</select>
+<%- end -%>
+
 <select class="tracker_id helper" id="tracker_id_options">
   <%-  Tracker.find_all_by_id(Setting.plugin_redmine_backlogs[:story_trackers]).each do |tracker| %>
   <option value="<%= tracker.id %>"><%= tracker.name %></option>

--- a/app/views/rb_stories/_story.html.erb
+++ b/app/views/rb_stories/_story.html.erb
@@ -12,7 +12,15 @@
     <div class="t"><%= status_label_or_default(story) %></div>
     <div class="v"><%= status_id_or_default(story) %></div>
   </div>
-  <div class="story_points editable" fieldname="story_points"><%= story_points_or_empty(story) %></div>
+  <% if Setting.plugin_redmine_backlogs[:story_points].blank? %>
+  <div class="story_points editable story_points_text" fieldname="story_points"><%= story_points_or_empty(story) %></div>
+  <% else %>
+  <div class="story_points editable story_points_select" fieldtype="select" fieldname="story_points">
+	  <% %w(t v).each do |c| %>
+		  <div class="<%=h c %>"><%= story_points_or_empty(story) %></div>
+	  <% end %>
+  </div>
+  <% end %>
   <div class="fixed_version_id"><%= story.fixed_version_id %></div>
   <div class="user_status"><%= story.author == User.current ? '+' : '-' %>c<%= story.assigned_to == User.current ? '+' : '-' %>a</div>
   <div class="higher_item_id"><%= story.higher_item.blank? ? '' : story.higher_item.id %></div>

--- a/app/views/shared/_settings.html.erb
+++ b/app/views/shared/_settings.html.erb
@@ -89,3 +89,9 @@
         <%= content_tag(:label, l(:backlogs_wiki_template)) %>
         <%= text_field_tag("settings[wiki_template]", Setting.plugin_redmine_backlogs[:wiki_template]) %>
     </p>
+	<p>
+		<%= content_tag(:label, l(:field_story_points)) %>
+		<%= l(:comma_delimited_numbers) %><br>
+		<%= l(:use_free_text_if_empty) %><br>
+		<%= text_field_tag("settings[story_points]", Setting.plugin_redmine_backlogs[:story_points]) %>
+	</p>

--- a/assets/stylesheets/master_backlog.css
+++ b/assets/stylesheets/master_backlog.css
@@ -339,6 +339,9 @@
   top:1px;
   width:28px;
 }
+#backlogs_container .stories .story .story_points .v {
+  display:none;
+}
 #backlogs_container .stories .story .fixed_version_id,
 #backlogs_container .stories .story .higher_item_id,
 #backlogs_container .stories .story .user_status {
@@ -462,7 +465,17 @@
   top:4px;
   width:68px;
 }
-#backlogs_container .stories .story.editing .story_points.editor{
+#backlogs_container .stories .story.editing select.story_points.editor {
+  display:block;
+  left:540px;
+  margin:0;
+  padding: 0px;
+  height: inherit;
+  top: 4px;
+  width: 40px;
+  overflow: visible;
+}
+#backlogs_container .stories .story.editing input.story_points.editor {
   display:block;
   height:10px;
   left:540px;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,9 @@ en:
   field_blocks: "Blocks"
   error_must_have_comma_delimited_list: "must have a comma delimited list of story or task IDs"
 
+  comma_delimited_numbers: "Comma delimited numbers"
+  use_free_text_if_empty: "Use text field instead of dropdown if empty"
+
   field_tracker_id: Tracker ID
   error_inclusion: "is not included in the list"
   

--- a/init.rb
+++ b/init.rb
@@ -33,7 +33,8 @@ Redmine::Plugin.register :redmine_backlogs do
                          :story_trackers  => nil, 
                          :task_tracker    => nil, 
                          :card_spec       => nil,
-                         :taskboard_card_order => 'story_follows_tasks'
+                         :taskboard_card_order => 'story_follows_tasks',
+                         :story_points    => "1,2,3,5,8"
                        }, 
            :partial => 'shared/settings'
 


### PR DESCRIPTION
Usually, story point is choosen from prepared number set(e.g [1,3,5,8] etc).
This patch can edit story point with drop down list with prepared number set(configurable with plugin's setting page), or text field(same as current behaviour).
