### PR TITLE
Taskboard improvements

### DIFF
--- a/app/views/rb_tasks/_task.html.erb
+++ b/app/views/rb_tasks/_task.html.erb
@@ -7,10 +7,12 @@
     <div class="t"><%= assignee_name_or_empty(task) %></div>
     <div class="v"><%= assignee_id_or_empty(task) %></div>
   </div>
-  <div class="priority_id editable"  fieldtype="select"  fieldname="priority_id">
-    <div class="t"><%= task.priority.name %></div>
-    <div class="v"><%= task.priority_id %></div>
-  </div>
+  <% if task.priority_id != IssuePriority.default.id %>
+    <div class="priority_id editable"  fieldtype="select"  fieldname="priority_id">
+      <div class="t"><%= task.priority.name %></div>
+      <div class="v"><%= task.priority_id %></div>
+    </div>
+  <% end %>
   <div class="estimated_hours editable" fieldname="estimated_hours"><%= estimated_hours(task) %></div>
   <% if User.current.allowed_to?(:log_time, @project) && @settings[:timelog_from_taskboard]=='enabled'  %>
     <div class="time_entry_hours editable" style="display: none" fieldname="time_entry_hours"></div>


### PR DESCRIPTION
Two fairly trivial commits that hide a the duplicate issue ID for a task on the task board and the issue priority if it's default. This should make the task board calmer and make it easier to spot low/high priority items.
