### PR TITLE
Properly hide the duplicate task ID using CSS

### DIFF
--- a/assets/stylesheets/taskboard.css
+++ b/assets/stylesheets/taskboard.css
@@ -193,6 +193,9 @@ See RB.Taskboard.initialize()
   text-align:right;
   width:82px;
 }
+.issue .id .v{
+  display:none;
+}
 .issue .id a{
   opacity:1.0;
 }


### PR DESCRIPTION
This small patch should fix it without breaking AJAX.
