### PR TITLE
Regression fix: link to a non-embedded task board

### DIFF
--- a/app/views/shared/_view_issues_sidebar.html.erb
+++ b/app/views/shared/_view_issues_sidebar.html.erb
@@ -43,7 +43,7 @@
         <h3><%= l(:label_sprint_name, {:name => sprint.name}) %></h3>
         <%= link_to(l(:label_task_board), {
                 :controller => 'rb_taskboards',
-                :action => 'embedded',
+                :action => 'show',
                 :sprint_id => sprint.id
                 })
         %><br/>


### PR DESCRIPTION
Commit f0165200350d1d51fa62881a24f850a3be6f41b0 introduced a regression where
the task board links to an embedded view, but this is incorrect since this view
doesn't exist.
