### PR TITLE
Issue 226

### DIFF
--- a/app/views/rb_server_variables/show.js.erb
+++ b/app/views/rb_server_variables/show.js.erb
@@ -38,6 +38,14 @@ RB.constants = {
     }
   %>
   story_states: <%= transitions.to_json %>,
+
+  <%
+    project_versions = {}
+    RbStory.find(:all, RbStory.find_params( :include_backlog => true, :project_id => @project.id, :sprint_id => @project.shared_versions.collect{|v| v.id})).each {|story|
+      project_versions[story.project.id.to_s] ||= story.project.shared_versions.collect{|v| v.id.to_s }
+    }
+  %>
+  project_versions: <%= project_versions.to_json %>,
   <% end %>
 
   <% if @section == 'taskboard'


### PR DESCRIPTION
In 727cbec44c4d79b599eb2f3f60604e9b7acd8a39 the definition of project versions
was removed which caused a regression that broke drag & drop in the master
backlogs. This fixes issue #226.
