### PR TITLE
Changed to "no"

### DIFF
--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -1,5 +1,5 @@
 --- 
-en: 
+"no": 
   backlogs_active: aktiv
   backlogs_any: noen
   backlogs_card_specification: Etikettype for utskrift


### PR DESCRIPTION
Norwegian translation was set to "en" instead of "no." This change addresses that mishap. 
