### PR TITLE
Fix for #230 - Burndown chart show task as resolved if less than one hour is estimated

### DIFF
--- a/app/models/rb_story.rb
+++ b/app/models/rb_story.rb
@@ -224,7 +224,7 @@ class RbStory < Issue
         # points are accepted when the state is accepted
         @burndown[:points_accepted] = {:points => @burndown[:points], :accepted => accepted}.transpose.collect{|p| p[:accepted] ? p[:points] : nil }
         # points are resolved when the state is accepted _or_ the hours are at zero
-        @burndown[:points_resolved] = {:points => @burndown[:points], :hours => @burndown[:hours], :accepted => accepted}.transpose.collect{|p| (p[:hours].to_i == 0 || p[:accepted]) ? p[:points] : 0}
+        @burndown[:points_resolved] = {:points => @burndown[:points], :hours => @burndown[:hours], :accepted => accepted}.transpose.collect{|p| (p[:hours].to_f == 0 || p[:accepted]) ? p[:points] : 0}
 
         # set hours to zero after the above when the story is not active, would affect resolved when done before this
         @burndown[:hours] = {:hours => @burndown[:hours], :active => active}.transpose.collect{|h| h[:active] ? h[:hours] : 0}


### PR DESCRIPTION
Changed rb_story check float in stead of integer to avoid marking a story as resolved if less than one hour remains.
