### PR TITLE
Added tracker statistics tooltip on backlog view + fixed recalculation

### DIFF
--- a/app/views/rb_master_backlogs/_backlog.html.erb
+++ b/app/views/rb_master_backlogs/_backlog.html.erb
@@ -7,7 +7,7 @@
     </div>
     <%- if backlog[:sprint] %>
       <%= render :partial => "rb_sprints/sprint", :object => backlog[:sprint] %>
-      <div class="velocity"> </div>
+      <div class="velocity story_tooltip" title="<b>Tracker statistics</b><br />"> </div>
     <%- else %>
       <div class="label"><%=l(:label_product_backlog).titleize %></div>
       <%= link_to l(:label_close_completed_sprints), close_completed_project_versions_path(@project), :class => "close_sprint", :method => :put, :target => "_blank" %>

--- a/assets/javascripts/backlog.js
+++ b/assets/javascripts/backlog.js
@@ -176,11 +176,24 @@ RB.Backlog = RB.Object.create({
 
   recalcVelocity: function(){
     if( !this.isSprintBacklog() ) return true;
+    var tracker_total = new Array();
     total = 0;
     this.getStories().each(function(index){
+      var story = RB.$(this).data('this');
+      var story_tracker = story.getTracker();
       total += RB.$(this).data('this').getPoints();
+      if ('undefined' == typeof(tracker_total[story_tracker])) {
+         tracker_total[story_tracker] = 0;
+      }
+      tracker_total[story_tracker] += story.getPoints();
     });
-    this.$.children('.header').children('.velocity').text(total);
+    var sprint_points = this.$.children('.header').children('.velocity');
+    sprint_points.text(total);
+    var tracker_summary = "<b>Tracker statistics</b><br />";
+    for (var t in tracker_total) {
+       tracker_summary += '<b>' + t + ':</b> ' + tracker_total[t] + '<br />';
+    }
+    sprint_points.qtip('option', 'content.text', tracker_summary);
   },
 
   showBurndownChart: function(event){

--- a/assets/javascripts/story.js
+++ b/assets/javascripts/story.js
@@ -15,6 +15,10 @@ RB.Story = RB.Object.create(RB.Issue, RB.EditableInplace, {
     j.find(".editable").live('mouseup', this.handleClick);
   },
 
+  afterUpdate: function(data, textStatus, xhr){
+    this.$.parents('.backlog').data('this').recalcVelocity();
+  },
+
   beforeSave: function(){
     // Do nothing
   },
@@ -68,6 +72,10 @@ RB.Story = RB.Object.create(RB.Issue, RB.EditableInplace, {
   getPoints: function(){
     points = parseInt( this.$.find('.story_points').first().text() );
     return ( isNaN(points) ? 0 : points );
+  },
+
+  getTracker: function(){
+	return this.$.find('.tracker_id .t').text();
   },
 
   getType: function(){


### PR DESCRIPTION
Added tracker statistics tooltip on backlog view + fixed recalculation of story points when updating story.

We usually need the story points per tracker info when doing the sprint planning because our team is divided in two so we need to know if the allocation roughly fits the number of points per group. As we do the planning using the master backlog I figured a tooltip was the best way to squeeze in more information.
I have also updated the story class in javascript to do a recalculation of the story points every time a story is updated as this might change the story points. Previously the complete backlog had to be reloaded when doing this.
Screenshot: http://i.imgur.com/QJiLz.png

This is very much "learning by doing" javascript from my part so I'll appreciate if someone can find the time to test it before a merge.

Thanks in advance,
Bo
