### PR TITLE
Changed taskboard stylesheet to hide ui-datepicker-div.

### DIFF
--- a/assets/stylesheets/taskboard.css
+++ b/assets/stylesheets/taskboard.css
@@ -400,3 +400,6 @@ See RB.Taskboard.initialize()
 #warning{
   background-image:url('images/warning.png');
 }
+#ui-datepicker-div{
+  display: none;
+}


### PR DESCRIPTION
Solution found here: http://forum.jquery.com/topic/jquery-ui-datepicker-initial-display-none-fixup

Fixes #316
