### PR TITLE
Only show the project if it's different from the global project

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -60,7 +60,9 @@
             <%= link_to story.id, {:controller => 'issues', :action => 'show', :id => story.id}, { :target => "_blank" } %>
           </div>
           <div class="subject"><%= story.subject %></div>
-          <div class="id project"><%= story.project %></div>
+          <%- if @project != story.project %>
+            <div class="id project"><%= story.project %></div>
+          <%- end %>
           <div class="story_points editable" fieldname="story_points" fieldlabel="<%=l(:field_story_points)%>"><%= story.story_points %></div>
         </div>
       </td>


### PR DESCRIPTION
This is a proposal. Benefit is that you win some vertical space if the project is the same. Downside is that a story is now a variable height if there are multiple projects involved. I think that for most cases this is an improvement and the downsides are small enough to accept it.
