### PR TITLE
Important performance fix

### DIFF
--- a/db/migrate/027_add_index_on_issues_position.rb
+++ b/db/migrate/027_add_index_on_issues_position.rb
@@ -1,0 +1,9 @@
+class AddIndexOnIssuesPosition < ActiveRecord::Migration
+  def self.up
+    add_index :issues, :position 
+  end
+
+  def self.down
+    remove_index :issues, :position 
+  end
+end


### PR DESCRIPTION
Hi,

first of all - thanks a lot for such great plugin!

It took about 15s to render master_backlog page containing only 20 stories on our redmine setup (we use PostgreSQL). I investigated a bit and found that it is missing one important index. I'm surprised why other peeps don't have this issue, maybe on Mysql it's not so slow without that index.

Thanks!
Saulius
