### PR TITLE
Change story point color in taskboard.

### DIFF
--- a/assets/stylesheets/taskboard.css
+++ b/assets/stylesheets/taskboard.css
@@ -152,7 +152,7 @@ See RB.Taskboard.initialize()
   -webkit-border-radius:15px 15px 15px 15px;
   border-radius:15px 15px 15px 15px;
   border:2px solid #FFFFFF;
-  background-color:#33A1DE;
+  background-color:#FF8800;
   color:#FFFFFF;
   font-size:1em;
   position:absolute;


### PR DESCRIPTION
In taskboard, story point background color is blue. IMO, blue is not missmatch for current stylesheet.

I propose change the color to orange. 
