### PR TITLE
Hide button and select box on taskboard print-out

### DIFF
--- a/assets/stylesheets/global_print.css
+++ b/assets/stylesheets/global_print.css
@@ -1,3 +1,9 @@
 #toolbar .links{
   display:none !important;
 }
+.add_new {
+    display: none;
+}
+.breadcrumbs select {
+    display: none;
+}


### PR DESCRIPTION
A small change to the print CSS to hide the 'add new task' button and project selection box on the print-out of the task board.
