### PR TITLE
Estimated hours not set when creating task

### DIFF
--- a/app/models/rb_task.rb
+++ b/app/models/rb_task.rb
@@ -23,6 +23,7 @@ class RbTask < Issue
     blocks = params.delete('blocks')
 
     task = new(attribs)
+    task.estimated_hours = task.remaining_hours
     if params['parent_issue_id']
       parent = Issue.find(params['parent_issue_id'])
       task.start_date = parent.start_date


### PR DESCRIPTION
I don't know if this is a bug or on purpose. After the change back to remaining/estimated hours the estimated hours is not set when creating a task.
As far as I can see the remaining hours is correctly used to display remaining hours on the burndown chart.

This fix sets estimated hours = remaining hours on creation of a task.

/Bo
