### PR TITLE
Permission setting to enable remaining hours for specific roles

### DIFF
--- a/app/views/rb_tasks/_task.html.erb
+++ b/app/views/rb_tasks/_task.html.erb
@@ -15,7 +15,9 @@
       <div class="v"><%= task.priority_id %></div>
     </div>
   <% end %>
-  <div class="remaining_hours editable" fieldname="remaining_hours" fieldlabel="<%=l(:field_remaining_hours)%>"><%= remaining_hours(task) %></div>
+  <% if User.current.allowed_to?(:update_remaining_hours, @project) %>
+    <div class="remaining_hours editable" fieldname="remaining_hours" fieldlabel="<%=l(:field_remaining_hours)%>"><%= remaining_hours(task) %></div>
+  <% end %>
   <% if User.current.allowed_to?(:log_time, @project) && @settings[:timelog_from_taskboard]=='enabled'  %>
     <div class="time_entry_hours editable" style="display: none" fieldname="time_entry_hours" fieldlabel="<%=l(:field_time_entry_hours)%>"></div>
     <% if User.current.allowed_to?(:edit_time_entries, @project) %>

--- a/init.rb
+++ b/init.rb
@@ -113,6 +113,8 @@ Redmine::Plugin.register :redmine_backlogs do
     permission :create_tasks,           { :rb_tasks => [:new, :create]  }
     permission :update_tasks,           { :rb_tasks => [:edit, :update] }
     
+    permission :update_remaining_hours, { :rb_tasks => [:edit, :update] }
+
     # Impediment permissions
     # :show_impediments and :list_impediments are implicit in :view_sprints
     permission :create_impediments,     { :rb_impediments => [:new, :create]  }

--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -56,13 +56,15 @@ module BacklogsPlugin
 
         snippet = ''
 
+        project = context[:project]
+
         if issue.is_story?
           snippet += "<tr><th>#{l(:field_story_points)}</th><td>#{RbStory.find(issue.id).points_display}</td></tr>"
           vbe = issue.velocity_based_estimate
           snippet += "<tr><th>#{l(:field_velocity_based_estimate)}</th><td>#{vbe ? vbe.to_s + ' days' : '-'}</td></tr>"
         end
 
-        if issue.is_task?
+        if issue.is_task? && User.current.allowed_to?(:update_remaining_hours, project) != nil
           snippet += "<tr><th>#{l(:field_remaining_hours)}</th><td>#{issue.remaining_hours}</td></tr>"
         end
 


### PR DESCRIPTION
This change implements a permission setting to enable the usage
of the 'Remaining hours' field in the task board view and issue
view.

Relates to: http://forum.redminebacklogs.net/Field-permissions-td3577153.html

Note: setting this one checked by default might be more backwards compatible, but couldn't find how to do that ;-)
