### PR TITLE
Predefined story points that are of integer won't be selected in master backlog

### DIFF
--- a/app/views/rb_stories/_helpers.html.erb
+++ b/app/views/rb_stories/_helpers.html.erb
@@ -7,7 +7,7 @@
 
 <%- unless Setting.plugin_redmine_backlogs[:story_points].blank? -%>
 <select class="story_points helper" id="story_points_options">
-	<%- (['']+Setting.plugin_redmine_backlogs[:story_points].split(/,/)).each do |point| %>
+	<%- (['']+Setting.plugin_redmine_backlogs[:story_points].split(/,/).collect(&:to_f)).each do |point| %>
 	<option value="<%=h point %>"><%=h point %></option>
 	<%- end %>
 </select>


### PR DESCRIPTION
I have predefined "1,2,3,5,8" for story points at the settings page. However, when I inline edit a story with 2.0 story points at the master backlog page, the drop down will select the blank value as "2.0" doesn't equal "2". One of the solution is to define "1.0,2.0,3.0,5.0,8.0" for predefined story points instead of "1,2,3,5,8", but it should be better to always convert the predefined values to float.
