### PR TITLE
Fixes javascript error when showing burndown chart

### DIFF
--- a/assets/javascripts/burndown.js
+++ b/assets/javascripts/burndown.js
@@ -71,10 +71,10 @@ RB.burndown.configure = function() {
   var disabled = RB.burndown.options.disabled_series();
   var cb;
 
-  for (i in disabled) {
-    cb = RB.$('#burndown_series_' + disabled[i]);
+  RB.$.each(disabled, function(index, value) {
+    cb = RB.$('#burndown_series_' + value);
     if (cb) { cb.attr('checked', false); }
-  }
+  });
 
   var legend = RB.burndown.options.show_legend();
   RB.$('#burndown_legend_' + legend).attr('checked', true);


### PR DESCRIPTION
There was a little error using in for traversing an object instead of an array (also that construction doesn't work on IE7) so I just changed it to use Jquery.each function
