### PR TITLE
Statisctics: gsub is a String method

### DIFF
--- a/lib/backlogs_project_patch.rb
+++ b/lib/backlogs_project_patch.rb
@@ -39,12 +39,16 @@ module Backlogs
       Statistics.active_tests.sort.each{|m|
         r = send(m.intern)
         next if r.nil? # this test deems itself irrelevant
-        m.gsub!(/^test_/, '')
-        @statistics[r ? :succeeded : :failed] << (m.gsub(/^test_/, '') + (r ? '' : '_failed'))
+        @statistics[r ? :succeeded : :failed] <<
+          (m.to_s.gsub(/^test_/, '') + (r ? '' : '_failed'))
       }
       Statistics.stats.sort.each{|m|
         v = send(m.intern)
-        @statistics[:values][m.gsub(/^stat_/, '')] = v unless v.nil? || (v.respond_to?(:"nan?") && v.nan?) || (v.respond_to?(:"infinite?") && v.infinite?)
+        @statistics[:values][m.to_s.gsub(/^stat_/, '')] =
+          v unless
+                   v.nil? ||
+                   (v.respond_to?(:"nan?") && v.nan?) ||
+                   (v.respond_to?(:"infinite?") && v.infinite?)
       }
 
       if @statistics[:succeeded].size == 0 && @statistics[:failed].size == 0


### PR DESCRIPTION
This fixes undefined "gsub" method for "m" (which is a Symbol) in Rails3 with ruby 1.9
Should also work in Rails 2.3 with ruby 1.8
