### PR TITLE
Fix extended_timelog feature test (no such project eCookbook)

### DIFF
--- a/features/step_definitions/_given_steps.rb
+++ b/features/step_definitions/_given_steps.rb
@@ -436,8 +436,8 @@ Given /^I am logging time for task (.+)$/ do |subject|
   page.driver.response.status.should == 200
 end
 
-Given /^I am viewing log time for the ecookbook project$/ do
-  visit "/projects/#{@project}/time_entries"
+Given /^I am viewing log time for the (.*) project$/ do |project_id|
+  visit "/projects/#{project_id}/time_entries"
   click_link('Log time')
   page.driver.response.status.should == 200
 end


### PR DESCRIPTION
Don't know whether this test passes in Rails 2, but in Rails 3 I have "no such project eCookbook"
It is because @project when converted to string is not project_id, but its human readable name.
