### PR TITLE
Edit both issue name and description from TaskBoard #63

### DIFF
--- a/app/views/rb_tasks/_task.html.erb
+++ b/app/views/rb_tasks/_task.html.erb
@@ -5,6 +5,7 @@
     <div class="v"><%= id_or_empty(task) %></div>
   </div>
   <div class="subject editable" fieldtype="textarea" fieldname="subject" fieldlabel="<%=l(:field_subject)%>"><%= h task.subject %></div>
+  <div class="description editable" style="display: none" fieldtype="textarea" fieldname="description" fieldlabel="<%=l(:field_description)%>"><%= h task.description %></div>
   <div class="assigned_to_id editable" fieldtype="select" fieldname="assigned_to_id" fieldlabel="<%=l(:field_assigned_to)%>">
     <div class="t"><%= assignee_name_or_empty(task) %></div>
     <div class="v"><%= assignee_id_or_empty(task) %></div>

--- a/assets/stylesheets/taskboard.css
+++ b/assets/stylesheets/taskboard.css
@@ -223,6 +223,7 @@ See RB.Taskboard.initialize()
   padding:2px;
   width:81px;
 }
+
 .issue.closed .subject.editable{
   text-decoration:line-through;
 }
@@ -351,6 +352,11 @@ See RB.Taskboard.initialize()
 }
 #task_editor .subject{
   height:65px;
+  width:272px;
+}
+
+#task_editor .description{
+  height:80px;
   width:272px;
 }
 #task_editor .remaining_hours,


### PR DESCRIPTION
I've modified task board so that description field is available in task board for issues. It's feature request #63
