### PR TITLE
Show burndown charts with User timezone dates

### DIFF
--- a/app/views/rb_burndown_charts/_burndown.html.erb
+++ b/app/views/rb_burndown_charts/_burndown.html.erb
@@ -6,7 +6,11 @@
       series = burndown.series.sort{|a, b| l("label_#{a}") <=> l("label_#{b}") }
       dates = sprint.days(:all)
 
-      ticks = dates.collect{|d| Time.local(d.year, d.mon, d.mday) }.collect{|t| t.strftime('%a')[0, 1].downcase + ' ' + t.strftime(::I18n.t('date.formats.short')) }
+      ticks = dates.collect{|d|
+        t = Time.utc(d.year, d.mon, d.mday)
+        zone = User.current.time_zone
+        zone ? t.in_time_zone(zone) : t
+      }.collect{|t| t.strftime('%a')[0, 1].downcase + ' ' + t.strftime(::I18n.t('date.formats.short')) }
       ticks = (0..dates.size * 2).collect{|i| [i, (i % 2 == 0 ? ' ' : ticks[(i-1)/2] + ' ')] }
 
       chart = {


### PR DESCRIPTION
At the moment, burndown charts are displayed in whatever the server's timezone is.
That poses problems when servers are configured for a timezone other than the one in which redmine is being used (for instance, our office is in Pacific Time, but all our servers are configured to run in UTC).

This is the same method that Redmine uses for transforming dates on issue comments.
