### PR TITLE
Redmine 1.4.0 compatibility

### DIFF
--- a/app/models/rb_task.rb
+++ b/app/models/rb_task.rb
@@ -13,7 +13,9 @@ class RbTask < Issue
     if Issue.const_defined? "SAFE_ATTRIBUTES"
       safe_attributes_names = RbTask::SAFE_ATTRIBUTES
     else
-      safe_attributes_names = Issue.new.safe_attribute_names
+      safe_attributes_names = Issue.new(
+        :project_id=>params[:project_id] # required to verify "safeness"
+      ).safe_attribute_names
     end
     attribs = params.select {|k,v| safe_attributes_names.include?(k) }
     attribs = Hash[*attribs.flatten] if attribs.is_a?(Array)


### PR DESCRIPTION
Since Redmine 1.4.0, to determene safeness of an attribute, it is required
to pass project_id.

http://www.redmine.org/projects/redmine/repository/revisions/8198/diff/trunk/app/models/issue.rb

edavis10/redmine@cd0113a2875f7261495d7abbd11dbb10d650848c
