### PR TITLE
Change to "Show empty stories" behavior on taskboard

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -51,17 +51,19 @@
 
           RB.$(this).closest('tr').show();
           var hasVisTasks = 0;
+          var hasTasks = 0;  // Keep track if a story has tasks (visible or not)
 
           //Parse each task in the story and see if any tasks are not hidden
           RB.$("#tasks [id^="+storyID+"_]").each(function(){
             RB.$(this).children().each(function(){
+              hasTasks = 1
               if(RB.$(this).is(':visible'))
                 hasVisTasks = 1;
             });
           });
 
-          //Hide or show story row based on if any tasks are visable
-          if (hasVisTasks || showUnusedStories)
+          //Hide or show story row based on if any tasks are visible
+          if (hasVisTasks || (showUnusedStories && !hasTasks))
             RB.$(this).closest('tr').show();
           else
             RB.$(this).closest('tr').hide();


### PR DESCRIPTION
I have changed the user selection option 'Show empty stories' to show only _really_ empty stories. Thus stories which has all tasks hidden will not be shown when this option is selected.
This was the behavior I had in mind when I commented on the private/user selection issue and @svolpe nicely implemented in pull request #480.
As it's a behavior change I'd like to know if there are any objections before I merge?

Best regards,
Bo
