### PR TITLE
Redmine 1.4.1 & Ruby 1.9.3 support

### DIFF
--- a/app/controllers/rb_master_backlogs_controller.rb
+++ b/app/controllers/rb_master_backlogs_controller.rb
@@ -15,8 +15,8 @@ class RbMasterBacklogsController < RbApplicationController
     end
 
     last_story = RbStory.find(
-                          :first, 
-                          :conditions => ["project_id=? AND tracker_id in (?)", @project, RbStory.trackers],
+                          :first,
+                          :conditions => ["project_id=? AND tracker_id in (?)", @project.id, RbStory.trackers],
                           :order => "updated_on DESC"
                           )
     @last_update = (last_story ? last_story.updated_on : nil)
@@ -24,7 +24,7 @@ class RbMasterBacklogsController < RbApplicationController
     sprints_backlog_storie_of = RbStory.backlogs_by_sprint(@project, [sprints, c_sprints].flatten)
     @sprint_backlogs = sprints.map{ |s| { :sprint => s, :stories => sprints_backlog_storie_of[s.id] } }
     @c_sprint_backlogs = c_sprints.map{|s| { :sprint => s, :stories => sprints_backlog_storie_of[s.id] } }
-    
+
     respond_to do |format|
       format.html { render :layout => "rb"}
     end
@@ -44,22 +44,22 @@ class RbMasterBacklogsController < RbApplicationController
               :classname => 'show_burndown_chart'
              } if @sprint && @sprint.stories.size > 0 && @sprint.has_burndown?
     links << {:label => l(:label_stories_tasks),
-              :url => url_for(:controller => 'rb_queries', :action => 'show', :project_id => @project, :sprint_id => @sprint, :only_path => true)
+              :url => url_for(:controller => 'rb_queries', :action => 'show', :project_id => @project.id, :sprint_id => @sprint, :only_path => true)
              } if @sprint && @sprint.stories.size > 0
     links << {:label => l(:label_stories),
               :url => url_for(:controller => 'rb_queries', :action => 'show', :project_id => @project, :only_path => true)
              } unless @sprint
     links << {:label => l(:label_sprint_cards),
-              :url => url_for(:controller => 'rb_stories', :action => 'index', :project_id => @project.identifier, :sprint_id => @sprint, :only_path => true)
+              :url => url_for(:controller => 'rb_stories', :action => 'index', :project_id => @project.identifier, :sprint_id => @sprint, :format => 'pdf', :only_path => true)
              } if @sprint && BacklogsPrintableCards::CardPageLayout.selected && @sprint.stories.size > 0
     links << {:label => l(:label_product_cards),
-              :url => url_for(:controller => 'rb_stories', :action => 'index', :project_id => @project.identifier, :only_path => true)
+              :url => url_for(:controller => 'rb_stories', :action => 'index', :project_id => @project.identifier, :format => 'pdf', :only_path => true)
              } unless @sprint
     links << {:label => l(:label_wiki),
               :url => url_for(:controller => 'rb_wikis', :action => 'edit', :project_id => @project.id, :sprint_id => @sprint, :only_path => true)
              } if @sprint && @project.enabled_modules.any? {|m| m.name=="wiki" }
     links << {:label =>  l(:label_download_sprint),
-              :url => url_for(:controller => 'rb_sprints', :action => 'download', :sprint_id => @sprint, :only_path => true)
+              :url => url_for(:controller => 'rb_sprints', :action => 'download', :sprint_id => @sprint, :format => 'xml', :only_path => true)
              } if @sprint && @sprint.has_burndown?
     links << {:label => l(:label_reset),
               :url => url_for(:controller => 'rb_sprints', :action => 'reset', :sprint_id => @sprint, :only_path => true),

--- a/app/views/rb_server_variables/show.js.erb
+++ b/app/views/rb_server_variables/show.js.erb
@@ -84,9 +84,9 @@ if (RB.constants == null) {
           rescue #Workaround in order to support redmine 1.1.3
             allowed_statues = status.new_statuses_allowed_to(roles, tracker)
           end
-          
+
           allowed = allowed_statues.collect{|s| s.id.to_s}
-          
+
           transitions[:transitions][tracker_id][key][:default] ||= allowed[0]
 
           allowed.unshift(status_id)
@@ -97,5 +97,5 @@ if (RB.constants == null) {
     }
   %>
   RB.constants.story_states = <%= transitions.to_json %>;
-  RB.routes.backlog_menu = '<%= url_for(:controller => 'rb_master_backlogs', :action => 'menu', :project_id => @project.identifier, :only_path => true) %>';
+  RB.routes.backlog_menu = '<%= url_for(:controller => 'rb_master_backlogs', :action => 'menu', :project_id => @project.identifier, :format => 'json', :only_path => true) %>';
 <% end %>


### PR DESCRIPTION
Pull request again.

You already changed for RM 1.4.1. So, I have a bit suggestion.
Perhaps, you don't need my commits.

But I think it's not good way that you change map.connect from :project_id to just word 'sprint/project' on routes.rb. If you change params of link_to from @product to @product.id, it's ok. of course, it's my opinion as just beginner.

and I know one more problem. that's about new/edit action of rb_releases.

Otherwise, I'm grateful that you quickly supported RM 1.4.1. I want to help you as I can.
thanks.
