### PR TITLE
Correct routings of new/edit/snapshot action on rb_releases

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,9 @@ ActionController::Routing::Routes.draw do |map|
     rb.resource   :task,             :except => :index,             :controller => :rb_tasks,           :as => "task/:id"
     rb.resources  :tasks,            :only => :index,               :controller => :rb_tasks,           :as => "tasks/:story_id"
     rb.resource   :taskboard,        :only => :show,                :controller => :rb_taskboards,      :as => "taskboards/:sprint_id"
-    rb.resource   :release,          :only => :show,                :controller => :rb_releases,        :as => "release/:release_id"
-    rb.resources  :release,          :only => :edit,                :controller => :rb_releases,        :as => "release/:release_id"
-    rb.resources  :release,          :only => :destroy,             :controller => :rb_releases,        :as => "release/:release_id"
+    rb.resource   :release, :only => [:show, :edit, :destroy, :snapshot], :controller => :rb_releases,  :as => "release/:release_id",   :member => {:snapshot => :get, :edit => :post}
+    rb.resources  :release,          :only => :new,                 :controller => :rb_releases,        :as => "release/:project_id",   :new => { :new => :post }
     rb.resources  :releases,         :only => :index,               :controller => :rb_releases,        :as => "releases/:project_id"
-    rb.resources  :releases,         :only => :snapshot,            :controller => :rb_releases,        :as => "releases/:project_id"
 
     rb.connect    'issues/backlog/product/:project_id',             :controller => :rb_queries,           :action => 'show'
     rb.connect    'issues/backlog/sprint/:sprint_id',               :controller => :rb_queries,           :action => 'show'


### PR DESCRIPTION
Hi,

map.resources create only GET request of new/edit action.
But, changing releases needs POST request.

And if we use :only parameter in map.resources, we must write actions with same :as parameter in one line.
that is, ":only => [:show, :edit, :destroy, :snapshot],"

You think I understand release_controller, don't you?

So, routing result after change is below.

``` ruby
# rake routes RAILS_ENV=production | grep release
                       edit_rb_release GET             /rb/release/:release_id/edit(.:format)                                  {:controller=>"rb_releases", :action=>"edit"}
                   snapshot_rb_release GET             /rb/release/:release_id/snapshot(.:format)                              {:controller=>"rb_releases", :action=>"snapshot"}
                                       POST            /rb/release/:release_id/edit(.:format)                                  {:controller=>"rb_releases", :action=>"edit"}
                            rb_release GET             /rb/release/:release_id(.:format)                                       {:controller=>"rb_releases", :action=>"show"}
                                       DELETE          /rb/release/:release_id(.:format)                                       {:controller=>"rb_releases", :action=>"destroy"}
                        new_rb_release POST            /rb/release/:project_id/new(.:format)                                   {:controller=>"rb_releases", :action=>"new"}
                                       GET             /rb/release/:project_id/new(.:format)                                   {:controller=>"rb_releases", :action=>"new"}
                           rb_releases GET             /rb/releases/:project_id(.:format)                                      {:controller=>"rb_releases", :action=>"index"}
```
