### PR TITLE
set positioning of new first element in a backlog to start from 0

### DIFF
--- a/app/models/rb_story.rb
+++ b/app/models/rb_story.rb
@@ -146,8 +146,8 @@ class RbStory < Issue
       # if prev is the first story, move current to the 1st position
       if prev.blank?
         RbStory.connection.execute("update issues set position = position + 1")
-        # do stories start at position 1? rake task fix_positions indicates that.
-        RbStory.connection.execute("update issues set position = 1 where id = #{id}")
+        # stories do start at position 0
+        RbStory.connection.execute("update issues set position = 0 where id = #{id}")
 
       # if its predecessor has no position (shouldn't happen
       # - but happens if we add many stories using "new issues" and begin sorting),


### PR DESCRIPTION
7c74897 repositions starting at 0 (zero), which changes behavior of the fix_position_task. I wrongly assumed that stories start at position 1. The result is that my prior pull requests could introduce duplicates again (position 1 will get duplicated).
Here the adaption  of models/rb_story to the correct positioning.
- revert position of new first element in a backlog to 0, introduced in 44f0889b0a7, since 7c748975b6287 and ec2f6e3d0de4 changes behavior of starting at position 0.
