### PR TITLE
Rake install: Add an option to override unsupported version of redmine

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -20,7 +20,11 @@ namespace :redmine do
         raise "You are missing the '#{gem}' gem" unless installed
       }
 
-      puts Backlogs.platform_support(true)
+      raise_unsupported_error = true
+      if ['yes', 'true'].include?("#{ENV['override_unsupported']}".downcase)
+        raise_unsupported_error = false
+      end
+      puts Backlogs.platform_support(raise_unsupported_error)
 
       # Necessary because adding key-value pairs one by one doesn't seem to work
       Backlogs.setting[:points_burn_direction] ||= 'down'


### PR DESCRIPTION
I'm not sure if it's a proper way to do it, but I need to check install script with future version of Redmine (2.0.0) before it is released.
