### PR TITLE
require 'rubygems' need came before 'json'

### DIFF
--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -98,6 +98,7 @@ When /^(?:|I )attach the file "([^"]*)" to "([^"]*)"(?: within "([^"]*)")?$/ do 
 end
 
 Then /^(?:|I )should see JSON:$/ do |expected_json|
+  require 'rubygems'
   require 'json'
   expected = JSON.pretty_generate(JSON.parse(expected_json))
   actual   = JSON.pretty_generate(JSON.parse(response.body))

--- a/lib/backlogs_issues_controller_patch.rb
+++ b/lib/backlogs_issues_controller_patch.rb
@@ -1,4 +1,5 @@
 require_dependency 'issues_controller'
+require 'rubygems'
 require 'nokogiri'
 require 'json'
 


### PR DESCRIPTION
To solve this bug
# rake db:migrate RAILS_ENV=production

Please install RDoc 2.4.2+ to generate documentation.
rake aborted!
no such file to load -- json
