### PR TITLE
drop _tmp table only if it exists

### DIFF
--- a/db/migrate/033_unique_positions.rb
+++ b/db/migrate/033_unique_positions.rb
@@ -3,7 +3,7 @@ require 'benchmark'
 class UniquePositions < ActiveRecord::Migration
   def self.up
     begin
-      execute("drop table _backlogs_tmp_position")
+      execute("drop table if exists _backlogs_tmp_position")
     rescue Exception
     end
 

--- a/lib/tasks/fix_positions.rake
+++ b/lib/tasks/fix_positions.rake
@@ -3,7 +3,7 @@ namespace :redmine do
     desc "Remove duplicate positions in the issues table"
     task :fix_positions => :environment do
       begin
-        RbStory.connection.execute("drop table _backlogs_tmp_position")
+        RbStory.connection.execute("drop table if exists _backlogs_tmp_position")
       rescue
       end
         


### PR DESCRIPTION
This works nicely for both my mysql and pg environments.
