### PR TITLE
Fix PBL Story update feedback off-by-one-post

### DIFF
--- a/app/controllers/rb_sprints_controller.rb
+++ b/app/controllers/rb_sprints_controller.rb
@@ -33,6 +33,8 @@ class RbSprintsController < RbApplicationController
     begin
       # using this instead of becomes to work around #493
       result  = Version.find(@sprint.id).update_attributes attribs
+      # version.update_attributes does not change @sprint. Reloading it manually.
+      @sprint.reload
     rescue => e
       render :text => e.message.blank? ? e.to_s : e.message, :status => 400
       return


### PR DESCRIPTION
reg. #493
Effect:
On the Backlogs page 
 I see a sprint named 'Sprint 55 foobar'
 When i change the sprint name to 'Sprint 55 foobaz'
 Then i the request completes
And returns the old name 'Sprint 55 foobar'

 When i change the sprint name a second time to 'Sprint 55 foo'
Then it returns 'Sprint 55 foobaz'

 When i reload the page
Then i see a sprint named 'Sprint 55 foo'
