### PR TITLE
Update Gemfile for running cucumber tests with Rails 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,13 @@
 source :rubygems
 
+chiliproject_file = File.dirname(__FILE__) + "/lib/chili_project.rb"
+chiliproject = File.file?(chiliproject_file)
+
+deps = Hash.new
+@dependencies.map{|dep| deps[dep.name] = dep }
+rails3 = Gem::Dependency.new('rails', '~>3.0')
+RAILS_VERSION_IS_3 = rails3 =~ deps['rails']
+
 gem "holidays", "=1.0.3"
 gem "icalendar"
 gem "nokogiri"
@@ -8,24 +16,42 @@ gem "prawn"
 gem 'json'
 gem "system_timer" if RUBY_VERSION =~ /^1\.8\./ && RUBY_PLATFORM =~ /darwin|linux/
 
-# development gems
 #puts "RBL dev mode: " + File.join(File.expand_path(File.dirname(__FILE__)), 'backlogs.dev')
 #if File.exist?(File.join(File.expand_path(File.dirname(__FILE__)), 'backlogs.dev')) # this is actually the main Gemfile
+# development gems, sorted alphabetically
 group :development do
   gem 'ZenTest', "=4.5.0" # 4.6.0 has a nasty bug that breaks autotest
   gem 'autotest-rails'
-  gem "capybara", "~>1.1.0"
-  gem "cucumber", "=1.1.0"
-  gem 'cucumber-rails', :git => 'https://github.com/Vanuan/cucumber-rails.git', :branch => 'cucumber-rails2_v0.3.3'
-  gem "culerity", "=0.2.15"
+  if RAILS_VERSION_IS_3
+    gem 'capybara' unless chiliproject
+    gem 'cucumber-rails'
+    gem "culerity"
+  else
+    unless chiliproject
+      gem "capybara", "~>1.1.0"
+    end
+    gem "cucumber", "=1.1.0"
+    gem 'cucumber-rails', :git => 'https://github.com/Vanuan/cucumber-rails.git', :branch => 'cucumber-rails2_v0.3.3'
+    gem "culerity", "=0.2.15"
+  end
   gem "database_cleaner"
-  gem "gherkin", "~> 2.5.0"
+  if RAILS_VERSION_IS_3
+    gem "gherkin", "=2.6.8"
+    gem 'hoe', '1.5.1'
+  else
+    gem "gherkin", "~> 2.5.0"
+  end
   gem "poltergeist"
   gem "redgreen" if RUBY_VERSION < "1.9"
-  gem "rspec", "=1.3.1"
-  gem "rspec-rails", "=1.3.3"
+  if RAILS_VERSION_IS_3
+    gem "rspec", "=2.5.0"
+    gem "rspec-rails", "=2.5.0"
+  else
+    gem "rspec", "=1.3.1"
+    gem "rspec-rails", "=1.3.3"
+  end
   if RUBY_VERSION >= "1.9"
-    gem "simplecov", "=0.6.2"
+    gem "simplecov", "~>0.6"
   else
     gem "rcov"
   end


### PR DESCRIPTION
So here is it. Different set of gems is installed for Rails 2 and 3. Includes a fix for chiliproject, where capybara is already installed. Oh, and capybara version rewrite in rbl-setup should be removed then. Or changed to the recent version.
