### PR TITLE
set all ticks so checkbox shows the correct state on load.  #502

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -70,6 +70,7 @@
         });
       }
     });
+    RB.$("userlist").multiselect('checkAll');
   });
 </script>
 


### PR DESCRIPTION
Taskboard multiselect filter comes now with all items checked when the page loads, so the state of the widget reflects the taskboard's state.
I chose not to use RB.UserPreferences to further make the button useful, though, as im not fully clear of the stories behind that filter.
