### PR TITLE
#541 show a warning on taskboard if tasks tracker has no workflow

### DIFF
--- a/assets/javascripts/taskboard.js
+++ b/assets/javascripts/taskboard.js
@@ -21,8 +21,13 @@ RB.Taskboard = RB.Object.create(RB.Model, {
     self.updateColWidths();
     RB.$("#col_width input").bind('keyup', function(e){ if(e.which==13) self.updateColWidths() });
 
+    var tasks_lists = j.find("#tasks .list");
+    if (!tasks_lists || !tasks_lists.length) {
+      alert("There are no task states. Please check the workflow of your tasks tracker in the administration section.");
+      return;
+    }
     // Initialize task lists
-    j.find("#tasks .list").sortable({ 
+    tasks_lists.sortable({ 
       connectWith: '#tasks .list', 
       placeholder: 'placeholder',
       start: self.dragStart,


### PR DESCRIPTION
this is a workaround to just inform the user so he is not surprised.
Better solution might be to issue a _unconfigured in the backend and flash that for the administrator. But thats over my head right now...
