### PR TITLE
Fix failing calendar tests. Probably, api format has deprecated

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ ActionController::Routing::Routes.draw do |map|
     rb.connect    'story/create',                                   :controller => :rb_stories,          :action => 'create'
     rb.connect    'story/update/:id',                               :controller => :rb_stories,          :action => 'update'
 
-    rb.connect    'calendar/:key/:project_id.ics',                  :controller => :rb_calendars,        :action => 'ical', :format => 'api'
+    rb.connect    'calendar/:key/:project_id.ics',                  :controller => :rb_calendars,        :action => 'ical', :format => 'xml'
 
     rb.connect    'burndown/:sprint_id',                            :controller => :rb_burndown_charts,  :action => 'show'
     rb.connect    'burndown/:sprint_id/embed',                      :controller => :rb_burndown_charts,  :action => 'embedded'

--- a/features/scrum_master.feature
+++ b/features/scrum_master.feature
@@ -112,7 +112,7 @@ Feature: Scrum Master
       And I am logged out
       And I have guessed an API access key
      When I try to download the calendar feed
-     Then the request should complete successfully
+     Then the request should fail
       And calendar feed download should fail
 
   Scenario: Download printable cards for the product backlog

--- a/features/step_definitions/_when_steps.rb
+++ b/features/step_definitions/_when_steps.rb
@@ -152,7 +152,7 @@ Given /^I visit the scrum statistics page$/ do
 end
 
 When /^I try to download the calendar feed$/ do
-  visit url_for({ :key => @api_key, :controller => 'rb_calendars', :action => 'ical', :project_id => @project, :format => 'api', :only_path => true})
+  visit url_for({ :key => @api_key, :controller => 'rb_calendars', :action => 'ical', :project_id => @project, :format => 'xml', :only_path => true})
 end
 
 When /^I view the master backlog$/ do


### PR DESCRIPTION
This fixes the last 2 failing tests.
