### PR TITLE
don't load javascript files if we don't need that

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -257,6 +257,7 @@ module BacklogsPlugin
       end
 
       def view_layouts_base_html_head(context={})
+        return '' unless context[:request].fullpath().include?('/rb/')
         return '' if Setting.login_required? && !User.current.logged?
 
         if User.current.admin? && !context[:request].session[:backlogs_configured]


### PR DESCRIPTION
In order to  reduce the loading time,  we don't need to load javascript files from redmine_backlogs for all of pages,  load them only if it's related to "/rb/" urls.
