### PR TITLE
Fix migration to allow big tables migrations

### DIFF
--- a/db/migrate/020_flatten_story_positions.rb
+++ b/db/migrate/020_flatten_story_positions.rb
@@ -8,6 +8,8 @@ class FlattenStoryPositions < ActiveRecord::Migration
       t.column :position, :integer, :null => false
     end
 
+    execute "SET SQL_BIG_SELECTS=1"
+
     execute "insert into backlogs_tmp_issue_position
              select story.id, count(*) + 1
              from issues story


### PR DESCRIPTION
Fix error 

```
Mysql::Error: The SELECT would examine more than MAX_JOIN_SIZE rows; check your WHERE and use SET SQL_BIG_SELECTS=1 or SET SQL_MAX_JOIN_SIZE=# if the SELECT is okay: insert into backlogs_tmp_issue_position
```

when migrate big redmines
