### PR TITLE
we need to override the gradient not just the colour

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -133,7 +133,7 @@
     <%- @sprint.stories.each do |story| %>
     <tr>
       <td>
-        <div class="story <%= mark_if_closed(story) %>" style="<%= build_inline_style_color(story) %>">
+        <div class="story <%= mark_if_closed(story) %> " <%= build_inline_style(story) %>>
           <div class="id story_tooltip">
             <div class="tooltip_text"><%= render :partial => "rb_stories/tooltip", :object => story %></div>
             <div style="float:left; padding-left:3px; font-weight:bold;">


### PR DESCRIPTION
something like this works for firefox 12.

might mean the build_inline_style_color helper could be deleted too I suppose.
