### PR TITLE
favicon is not available for bookmarks on backlogs page

### DIFF
--- a/app/views/layouts/rb.html.erb
+++ b/app/views/layouts/rb.html.erb
@@ -5,6 +5,7 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="description" content="Redmine Backlogs" />
 <meta name="keywords" content="issue,bug,tracker,scrum,agile,plugin" />
+<%= favicon %>
 
 <%= call_hook :view_layouts_base_html_head %>
 


### PR DESCRIPTION
call favicon hook in header to support icons in bookmarks
as seen in redmine 1.4.2 base.html.erb, available in 2.0.2, too.
