### PR TITLE
ToolTip description fix

### DIFF
--- a/app/views/rb_stories/_tooltip.html.erb
+++ b/app/views/rb_stories/_tooltip.html.erb
@@ -6,4 +6,4 @@
 <b><%= I18n.t :story_estimation_hours %></b>: <%=h tooltip.estimated_hours %><br />
 <b><%= I18n.t :story_spent_time %></b>: <%= tooltip.spent_hours.round(2) %><br />
 <b><%= I18n.t :story_remaining_hours %></b>: <%=h tooltip.remaining_hours %>
-<p><b><%= I18n.t :story_description %></b><br /><%= tidy(textile_to_html(tooltip.description)) %></p>
+<p><b><%= I18n.t :story_description %></b><br /><%=raw tidy(textile_to_html(tooltip.description)) %></p>


### PR DESCRIPTION
Just a tiny fix to display properly the story description in its ToolTip
