### PR TITLE
redmine2 sidebar on apache with relative url root

### DIFF
--- a/features/sidebar.feature
+++ b/features/sidebar.feature
@@ -1,0 +1,87 @@
+Feature: Sidebar, which requires javascript to show
+  As a user
+  I want to have useful links in the redmine sidebar
+  So that i can quickly navigate to relevant views
+
+  Background:
+    Given the ecookbook project has the backlogs plugin enabled
+      And I am a team member of the project
+      And I have defined the following sprints:
+        | name       | sprint_start_date | effective_date |
+        | Sprint 001 | 2010-01-01        | 2010-01-31     |
+        | Sprint 002 | 2010-02-01        | 2010-02-28     |
+      And I have defined the following stories in the product backlog:
+        | subject |
+        | Story 1 |
+      And I have defined the following stories in the following sprints:
+        | subject | sprint     |
+        | Story A | Sprint 001 |
+        | Story B | Sprint 002 |
+      And backlogs setting show_burndown_in_sidebar is enabled
+      And the current date is 2010-01-04
+
+  @javascript
+  Scenario: Look at the sidebar on the default issues page
+     Given I am viewing the issues list
+     Then I should see "Sprints" within "#sidebar"
+      And I should see "Sprint 001" within "#sidebar"
+      And I should see "Sprint 002" within "#sidebar"
+      And I should see "eCookbook" within "#sidebar"
+      And I should see "Product backlog" within "#sidebar"
+    Given the current time is restored
+
+  @javascript
+  Scenario: Go to the sprint which is current
+     Given I am viewing the issues list
+     When I follow "Sprint 001"
+     Then I should see "Issues" within "#content"
+      And I should see "Story A" within "#content"
+      And I should see "Task board" within "#sidebar"
+      And I should see "Burndown" within "#sidebar"
+      And I should see "Sprint cards" within "#sidebar"
+      And I should see "Wiki" within "#sidebar"
+      And I should see "Impediments" within "#sidebar"
+      And I should see the mini-burndown-chart in the sidebar
+#TODO: from here click on Task board, Burndown, Impediments
+    Given the current time is restored
+
+  @javascript
+  Scenario: Go to the sprint which is current and then to the task board
+     Given I am viewing the issues list
+     When I follow "Sprint 001"
+      And I follow "Task board"
+     Then show me a screenshot at /tmp/1.png
+     Then I should see the taskboard
+    Given the current time is restored
+
+  @javascript
+  Scenario: Go to the sprint which is current and then to the burndown
+     Given I am viewing the issues list
+     When I follow "Sprint 001"
+      And I follow "Burndown"
+     Then show me a screenshot at /tmp/1.png
+     Then I should see the burndown chart of sprint Sprint 001
+    Given the current time is restored
+
+  @javascript
+  Scenario: Go to the product backlog using the sidebar
+     Given I am viewing the issues list
+     Then I should see "Product backlog" within "#sidebar"
+     When I follow "Product backlog"
+      And I should see "Issues" within "#content"
+      And I should see "Story 1" within "#content"
+    Given the current time is restored
+
+#  TODO:
+#  @javascript
+#  Scenario: Open backlog cards using the sidebar
+#     Given I am viewing the issues list
+#     Then I should see "Product backlog cards" within "#sidebar"
+#     When I follow "Product backlog cards"
+#      And I should see "Issues" within "#content"
+#      And I should see "Story 1" within "#content"
+#    Given the current time is restored
+
+#  @javascript
+#  Scenario: Check the url of the javascript snippet which loads the rb sidebar features - when using a relative url not on /
+#     Given I am viewing the issues list

--- a/features/step_definitions/_given_steps.rb
+++ b/features/step_definitions/_given_steps.rb
@@ -165,6 +165,10 @@ Given /^the (.*) project has the backlogs plugin enabled$/ do |project_id|
   Issue.connection.execute("update issues set position = (position - #{Issue.minimum(:position)}) + #{Issue.maximum(:position)} + 50000")
 end
 
+Given /^backlogs setting show_burndown_in_sidebar is enabled$/ do
+    Backlogs.setting[:show_burndown_in_sidebar] = 'enabled' #app/views/backlogs/view_issues_sidebar.html.erb
+end
+
 Given /^I have defined the following sprints:$/ do |table|
   @project.versions.delete_all
   table.hashes.each do |version|
@@ -484,6 +488,14 @@ Given /^I choose to copy (none|open|all) tasks$/ do |copy_option|
     field_id = page.find(:xpath, '//input[starts-with(@id,"copy_tasks_all")]')['id']
     choose(field_id)
   end
+end
+
+Given /^the current date is (.+)$/ do |new_time|
+  Timecop.travel(Date.parse(new_time))
+end
+
+Given /^the current time is restored$/ do
+  Timecop.return
 end
 
 Given /^I have defined the following releases:$/ do |table|

--- a/features/step_definitions/_then_steps.rb
+++ b/features/step_definitions/_then_steps.rb
@@ -16,6 +16,11 @@ Then /^I should see the burndown chart$/ do
   page.should have_css("#burndown_#{@sprint.id.to_s}")
 end
 
+Then /^I should see the burndown chart of sprint (.+)$/ do |sprint_name|
+  sprint = RbSprint.find_by_name(sprint_name)
+  page.should have_css("#burndown_#{sprint.id.to_s}")
+end
+
 Then /^I should see the Issues page$/ do
   page.should have_css("#query_form")
 end
@@ -282,6 +287,14 @@ Then /^the story named (.+) should have a task named (.+)$/ do |story_subject, t
 
   tasks = RbTask.find(:all, :conditions => { :subject => task_subject, :parent_id => stories.first.id })
   tasks.length.should == 1
+end
+
+Then /^I should see the mini-burndown-chart in the sidebar$/ do
+  page.should have_css("#sidebar .burndown_chart canvas.jqplot-base-canvas")
+end
+
+Then /^show me the html content$/ do
+  puts page.html
 end
 
 #only with phantomjs driver:

--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -35,21 +35,25 @@ module BacklogsPlugin
           end
 
           url_options = {
-            :only_path  => false,
+            :only_path  => true,
             :controller => :rb_hooks_render,
             :action     => :view_issues_sidebar,
-            :project_id => project.identifier,
-            :host => context[:request].host_with_port,
-            :protocol => context[:request].ssl? ? 'https' : 'http'
+            :project_id => project.identifier
           }
           url_options[:sprint_id] = sprint_id if sprint_id
+          if Rails::VERSION::MAJOR < 3
+            url = '' #actionpack-2.3.14/lib/action_controller/url_rewriter.rb is injecting relative_url_root
+          else
+            url = Redmine::Utils.relative_url_root #actionpack-3* is not???
+          end
+          url += url_for(url_options)
 
           # Why can't I access protect_against_forgery?
           return %{
             <div id="backlogs_view_issues_sidebar"></div>
             <script type="text/javascript">
               jQuery(document).ready(function() {
-                jQuery('#backlogs_view_issues_sidebar').load('#{url_for(url_options)}');
+                jQuery('#backlogs_view_issues_sidebar').load('#{url}');
               });
             </script>
           }


### PR DESCRIPTION
and some sidebar.feature tests (javascript enabled frontend)

This makes #609 work for me. Please have a look:

lib/backlog_hooks url_for behaves differently on rails2 and rails3 - relative_url_root is not injected anymore.
Note: the tests do not cover #609 yet, they only cover basic sidebar loading and viewing without relative_url_root set.
