### PR TITLE
Added story points as an issue filter

### DIFF
--- a/lib/backlogs_query_patch.rb
+++ b/lib/backlogs_query_patch.rb
@@ -40,7 +40,9 @@ module Backlogs
           backlogs_filters = {
             "backlogs_issue_type" => {  :type => :list,
                                         :values => [[l(:backlogs_story), "story"], [l(:backlogs_task), "task"], [l(:backlogs_impediment), "impediment"], [l(:backlogs_any), "any"]],
-                                        :order => 20 }
+                                        :order => 20 },
+            "story_points" => { :type => :float,
+                                :order => 21 }
                              }
         end
 


### PR DESCRIPTION
This commit adds story points as an issue filter. It utilizes redmine's float filter and thus merely adds code to backlogs. This has been tested manually using both text field and drop-down story points setting of backlogs.

Best regards,
Bo
