### PR TITLE
fix deprecated Rspec warning

### DIFF
--- a/features/support/setup.rb
+++ b/features/support/setup.rb
@@ -6,7 +6,7 @@ Cucumber::Rails::World.use_transactional_fixtures = true
 
 if Rails::VERSION::MAJOR >= 3
   require 'rspec/rails/matchers'
-  World(Rspec::Rails::Matchers::RoutingMatchers)
+  World(RSpec::Rails::Matchers::RoutingMatchers)
 end
 
 #Seed the DB


### PR DESCRIPTION
use RSpec instead of Rspec for test setup to avoid deprecation warning
