### PR TITLE
Update calls to errors object to be rails3 compatible. Fixes #672

### DIFF
--- a/app/models/rb_release.rb
+++ b/app/models/rb_release.rb
@@ -96,7 +96,7 @@ class RbRelease < ActiveRecord::Base
   include Backlogs::ActiveRecord::Attributes
 
   def dates_valid?
-    errors.add_to_base(l(:error_release_end_after_start)) if self.release_start_date >= self.release_end_date if self.release_start_date and self.release_end_date
+    errors.add(:base, l(:error_release_end_after_start)) if self.release_start_date >= self.release_end_date if self.release_start_date and self.release_end_date
   end
 
   def stories

--- a/app/models/rb_sprint.rb
+++ b/app/models/rb_sprint.rb
@@ -89,7 +89,7 @@ class RbSprint < Version
   validate :start_and_end_dates
 
   def start_and_end_dates
-    errors.add_to_base("Sprint cannot end before it starts") if self.effective_date && self.sprint_start_date && self.sprint_start_date >= self.effective_date
+    errors.add(:base, "sprint_end_before_start") if self.effective_date && self.sprint_start_date && self.sprint_start_date >= self.effective_date
   end
 
   def self.rb_scope(symbol, func)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -68,9 +68,11 @@ de:
     Falls sie dies als Fehler empfinden, so kontaktieren Sie den Administrator
   error_outro: Bitte beheben Sie die obigen Fehler bevor Sie erneut abschicken.
   error_release_end_after_start: Release Enddatum muss nach dem Startdatum liegen
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: ist bereits in Bearbeitung
   event_sprint_summary: ! '%{project}: %{summary}'
   field_assigned_to: Zugeordnet zu
+  field_base: ""
   field_backlogs_issue_type: Backlog Typ
   field_blocks: blockiert
   field_initial_story_points: Storypunkte zu Beginn

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -51,10 +51,12 @@ en-GB:
   error_no_workflow_for_task_tracker: You do not have access to the task tracker. If you believe this is an error, please have your administrator update the workflow.
   error_outro: Please correct the above errors before submitting again.
   error_release_end_after_start: Release end date has to be after start date
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: is already in use
   event_sprint_summary: "%{project}: %{summary}"
   field_assigned_to: Assigned To
   field_backlogs_issue_type: Backlog type
+  field_base: ""
   field_blocks: Blocks
   field_initial_story_points: Initial story points
   field_name: Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,9 +51,11 @@ en:
   error_no_workflow_for_task_tracker: You do not have access to the task tracker. If you believe this is an error, please have your administrator update the workflow.
   error_outro: Please correct the above errors before submitting again.
   error_release_end_after_start: Release end date has to be after start date
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: is already in use
   event_sprint_summary: "%{project}: %{summary}"
   field_backlogs_issue_type: Backlog type
+  field_base: ""
   field_blocks: Blocks
   field_initial_story_points: Initial story points
   field_name: Name

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -65,10 +65,12 @@ es:
   error_outro: Por favor, corrija los errores antes de volver a realizar la solicitud.
   error_release_end_after_start: Fecha del release final tiene que ser después de
     la fecha de inicio
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: ya se encuentra en uso
   event_sprint_summary: ! '%{projecto}: %{resumen}'
   field_assigned_to: Asignado a
   field_backlogs_issue_type: Tipo de backlog
+  field_base: ""
   field_blocks: Bloques
   field_initial_story_points: Puntos iniciales de la historia
   field_name: Nombre

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -69,11 +69,13 @@ fr:
   error_outro: Veuillez corriger les erreurs ci-dessus avant de soumettre à nouveau.
   error_release_end_after_start: La aate de fin de Release doit être faite après la
     date de début
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: !binary |-
     ZMOpasOgIHV0aWxpc8Op
   event_sprint_summary: ! '%{project}: %{summary}'
   field_assigned_to: !binary |-
     QXNzaWduw6kgw6A=
+  field_base: ""
   field_backlogs_issue_type: Type de backlog
   field_blocks: Blocks
   field_initial_story_points: Point de story initiale

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -51,9 +51,11 @@ ja:
   error_no_workflow_for_task_tracker: "タスクトラッカーのアクセス権がありません。エラーだと思う場合は、管理者にワークフローの更新を依頼してください"
   error_outro: 送信する前に、上記のエラーを訂正してください
   error_release_end_after_start: リリース終了日は開始日の後に設定してください
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: は既に利用されています
   event_sprint_summary: "%{project}: %{summary}"
   field_backlogs_issue_type: バックログタイプ
+  field_base: ""
   field_blocks: ブロック
   field_initial_story_points: 初期ストーリーポイント
   field_name: 名前

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -67,9 +67,11 @@ nl:
   error_outro: Verbeter a.u.b de eerdergenoemde problemen voordat u nogmaals verzend.
   error_release_end_after_start: De einddatum van de release moet na de start datum
     liggen
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: is al in gebruik
   event_sprint_summary: ! '%{project}: %{summary}'
   field_assigned_to: Toegekend aan
+  field_base: ""
   field_backlogs_issue_type: Backlog type
   field_blocks: Blokkeert
   field_initial_story_points: Initiële story points

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -64,10 +64,12 @@
     tilgang.
   error_outro: Vennligst rett feilene over før du forsøker igjen.
   error_release_end_after_start: Sluttdato for utgivelse må være etter startdato
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: er allerede i bruk
   event_sprint_summary: ! '%{project}: %{summary}'
   field_assigned_to: Assigned To
   field_backlogs_issue_type: Backlog type
+  field_base: ""
   field_blocks: Blokker
   field_initial_story_points: Initielle storypoenger
   field_name: Navn

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -51,9 +51,11 @@ pt-BR:
   error_no_workflow_for_task_tracker: You do not have access to the task tracker. If you believe this is an error, please have your administrator update the workflow.
   error_outro: Por favor corriga os erros antes de enviar novamente.
   error_release_end_after_start: Release end date has to be after start date
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: is already in use
   event_sprint_summary: "%{project}: %{summary}"
   field_assigned_to: Assigned To
+  field_base: ""
   field_backlogs_issue_type: Tipo de backlog
   field_blocks: Blocos
   field_initial_story_points: Initial story points

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -68,10 +68,12 @@ ru:
     If you believe this is an error, please have your administrator update the workflow.
   error_outro: Пожалуйста, исправьте вышепреведенные ошибки перед следующим запуском.
   error_release_end_after_start: Дата окончания версии должна быть после даты  начала
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: is already in use
   event_sprint_summary: ! '%{project}: %{summary}'
   field_assigned_to: Assigned To
   field_backlogs_issue_type: Тип бэклога
+  field_base: ""
   field_blocks: Блокировки
   field_initial_story_points: Начальная оценка истории
   field_name: Название

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -65,9 +65,11 @@ zh:
     If you believe this is an error, please have your administrator update the workflow.
   error_outro: 在再次提交之前，请先更正以上的错误。
   error_release_end_after_start: Release end date has to be after start date
+  error_sprint_end_before_start: Sprint cannot end before it starts
   error_taken: is already in use
   event_sprint_summary: ! '%{project}: %{summary}'
   field_assigned_to: Assigned To
+  field_base: ""
   field_backlogs_issue_type: Backlog类型
   field_blocks: ! '[[Blocks]]'
   field_initial_story_points: Initial story points

--- a/features/scrum_master.feature
+++ b/features/scrum_master.feature
@@ -143,3 +143,11 @@ Feature: Scrum Master
      Then the request should complete successfully
      Then the wiki page Sprint 001 should contain Sprint Template
 
+  Scenario: Update sprint with start date greater than end date
+    Given I am viewing the master backlog
+      And I want to edit the sprint named Sprint 001
+      And I want to set the sprint_start_date of the sprint to 2012-03-01
+      And I want to set the effective_date of the sprint to 2012-02-20
+     When I update the sprint
+     Then the server should return an update error
+      And the error message should say "Sprint cannot end before it starts"

--- a/features/step_definitions/_then_steps.rb
+++ b/features/step_definitions/_then_steps.rb
@@ -404,3 +404,8 @@ end
 Then /^open the remote inspector$/ do
   page.driver.debug
 end
+
+Then /^the error message should say "([^"]*)"$/ do |msg|
+  response_msg = page.find(:xpath,"//div[@class='errors']/div")
+  response_msg.text.strip.should == msg
+end


### PR DESCRIPTION
Change from deprecated "add_to_base" to "add(:base, ...".
Test added to feature/scrum-master.feature. Tested on rails3. Pull request allows travis to run test against rails2 before merging. (thanks for the tip @Vanuan)

/Bo
