### PR TITLE
Fixed color configuration layout at my setting's.

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -190,13 +190,12 @@ module BacklogsPlugin
         begin
           return %{
             </fieldset>
+            <fieldset class="box tabular">
             <h3>#{l(:label_backlogs)}</h3>
-            <div class="box tabular">
             <p>
               #{label :backlogs, :task_color}
               #{text_field :backlogs, :task_color, :value => context[:user].backlogs_preference[:task_color]}
             </p>
-            </div>
           }
         rescue => e
           exception(context, e)


### PR DESCRIPTION
Color configuration field in my/settings layout is broken with Redmine Local Avatars.
This request fix it.
