### PR TITLE
do not descend into tooltip for taskboard for sprintInfo

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -47,7 +47,7 @@
 
         //Parse through all the stories and hide the ones not used
         RB.$('.story').each(function() {
-          var sprintInfo = this.getElementsByClassName("id")[0].getElementsByTagName('a')[0];
+          var sprintInfo = RB.$(this).children('.id').children('a')[0];
           var storyID = sprintInfo.innerHTML;
 
           RB.$(this).closest('tr').show();


### PR DESCRIPTION
stories which have anchors/links in their description
  would break the 'hide empty stories' feature
