### PR TITLE
fixes #715 hide and uncheck the copy_subtasks button in redmine2.1 ui fr...

### DIFF
--- a/features/duplicate_story.feature
+++ b/features/duplicate_story.feature
@@ -28,6 +28,8 @@ Feature: Duplicate story
       Then the request should complete successfully
       And sprint Sprint 002 should contain Story 1A
 
+  #using javascript to disable redmine2.1 copy_subtasks button
+  @javascript
   Scenario: Duplicate story with tasks
     Given I am duplicating Story 1 to Story 1B for Sprint 003
       And I choose to copy open tasks

--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -153,6 +153,13 @@ module BacklogsPlugin
         end
       end
 
+      def view_issues_new_top(context={ })
+        #Remove the copy_subtasks functionality from redmine 2.1+ since backlogs offers it with a choice to copy only open tasks
+        project = context[:project]
+        return '' unless project.module_enabled?('backlogs')
+        return '<script type="text/javascript">$(function(){try{$("#copy_subtasks")[0].checked=false;$($("#copy_subtasks")[0].parentNode).hide();}catch(e){}});</script>' if (Redmine::VERSION::MAJOR == 2 && Redmine::VERSION::MINOR >= 1) || Redmine::VERSION::MAJOR > 2
+      end
+
       def view_versions_show_bottom(context={ })
         begin
           version = context[:version]


### PR DESCRIPTION
...ontend

I found no way to do this server-side. So for rm 2.1+ and rb enabled for each project, some injected client javascript unchecks and hides the 'copy subtasks' button from rm.
Travis now passes on 2.1.2.
