### PR TITLE
Bug in backlogs_query_patch.rb

### DIFF
--- a/lib/backlogs_query_patch.rb
+++ b/lib/backlogs_query_patch.rb
@@ -48,7 +48,7 @@ module Backlogs
                              }
         end
 
-        return @available_filters.merge(backlogs_filters)
+        @available_filters = @available_filters.merge(backlogs_filters)
       end
 
       def sql_for_field_with_backlogs_issue_type(field, operator, value, db_table, db_field, is_custom_filter=false)


### PR DESCRIPTION
**Problem:** when trying to dynamically add a new filter to @query by following code, nothing changed in @query. 

``` ruby
@query.available_filters[field_name] = hash_with_filter_params
```

This is because the old code always returns a new hash with result of the merge instead of a reference to the instance variable.

``` ruby
# Always returns a new hash with result of the merge
@available_filters.merge (backlogs_filters)

# Always returns a reference to the instance variable
@available_filters = @available_filters.merge (backlogs_filters)
```

This change allows to dynamically add filters with the following code: 

``` ruby
@query.available_filters[field_name] = { type: type, order: order, name: name, values: values }
```
