### PR TITLE
do not assume that RbIssueHistory does not exist when performing rebuild...

### DIFF
--- a/app/models/rb_issue_history.rb
+++ b/app/models/rb_issue_history.rb
@@ -54,7 +54,8 @@ class RbIssueHistory < ActiveRecord::Base
   end
 
   def self.rebuild_issue(issue, status=nil)
-    rb = RbIssueHistory.new(:issue_id => issue.id)
+    rb = RbIssueHistory.find_by_issue_id(issue.id)
+    rb = RbIssueHistory.new(:issue_id => issue.id) unless rb
 
     rb.history = [{:date => issue.created_on.to_date - 1, :origin => :rebuild}]
 


### PR DESCRIPTION
..._history
I don't know if thats the right thing to do, though. But the migration at least passes.

RbIssueHistory.rebuild_history seems to have sideeffects, so that other issues get a issues_history association when performing the rebuild.
I got a Story with a Task. The task gets first passed to rebuild_history, and affects it's story, which get the history assoc before the task is finished. Then later, the Story gets passed to rebuild_history, and the unique constraint fails as noted in #754.
