### PR TITLE
adapt for new labels.yaml file format

### DIFF
--- a/lib/backlogs_printable_cards.rb
+++ b/lib/backlogs_printable_cards.rb
@@ -101,7 +101,7 @@ module BacklogsPrintableCards
         end
       rescue => e
         Rails.logger.error "Backlogs printable cards: error loading #{layout['name']}: #{e}"
-        Rails.logger.info(e.backtrace.join("\n"))
+        Rails.logger.error(e.backtrace.join("\n"))
         @valid = false
       end
     end
@@ -233,7 +233,7 @@ module BacklogsPrintableCards
       }
     rescue => e
       Rails.logger.error("Backlogs printable cards: problem loading labels: #{e}")
-      Rails.logger.info(e.backtrace.join("\n"))
+      Rails.logger.error(e.backtrace.join("\n"))
     end
   end
 


### PR DESCRIPTION
platform: 2.1.5, 2.0.4
backlogs: master
ruby: 1.9.3

somewhen yaml behavior changed and now new downloaded labels are stored with class information. Upon loading we do not get a hash but the !ruby/object:BacklogsPrintableCards::CardPageLayout class instances.
Existing labels.yaml, stored without class information, are still loaded as hash.

Fixes my problems with running tests, fixes using labels on my 2.1.5 on ruby 1.9.3 test instance. also most probably fixes 2.1.2 installations.
