### PR TITLE
travis: require service postgresql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 release: 0.9.29
 services:
 - mysql
-- 
+- postgresql
 rvm:
 - 1.9.3
 - 1.8.7


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.5
backlogs:  # supported: 0.9.29
ruby:  # supported: 1.9.3, 1.8.7

fixes travis failing at:

```
5 $ sudo service start
6 start: unrecognized service
```
