### PR TITLE
fix #766 can't convert Hash into Array

### DIFF
--- a/app/models/rb_issue_history.rb
+++ b/app/models/rb_issue_history.rb
@@ -335,7 +335,7 @@ class RbIssueHistory < ActiveRecord::Base
 
       if parent_history_index.nil?
         # the record needs to be added, so add and sort (history needs to be sorted)
-        p.history.history = (p.history.history + parent_data).sort{|a, b| a[:date] <=> b[:date]}
+        p.history.history = (p.history.history + [parent_data]).sort{|a, b| a[:date] <=> b[:date]}
       else
         # there was an entry on this date, replace it
         p.history.history[parent_history_index] = parent_data


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.5, 2.2.0
backlogs:  # supported: 0.9.31
ruby:  # supported: 1.9.3, 1.8.7

Fixes exception when you try to add an issue with a parent issue id, but only when there is no history for that date.
