### PR TITLE
fix datepicker visibility on editing sprint

### DIFF
--- a/assets/stylesheets/master_backlog.css
+++ b/assets/stylesheets/master_backlog.css
@@ -556,7 +556,7 @@ ul li { vertical-align: bottom; } /* close IE7 gap between list items */
   position: relative;
   width: 498px;
   height: 30px;
-  z-index: 1000;
+  z-index: 1;
   line-height: 16px;
 }
 


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.5, 2.2.0
backlogs:  # supported: 0.9.32
ruby:  # supported: 1.9.3, 1.8.7

datepicker got hidden beneath the save/cancel buttons
