### PR TITLE
Fixed migration errors in v0.9.32

### DIFF
--- a/app/models/rb_issue_history.rb
+++ b/app/models/rb_issue_history.rb
@@ -103,7 +103,7 @@ class RbIssueHistory < ActiveRecord::Base
     }
 
     if ActiveRecord::Base.connection.tables.include?('rb_journals')
-      RbIssueHistory.connection.execute("select * from rb_journals where issue_id=#{issue.id}").sort{|a,b| a['timestamp'] <=> b['timestamp']}.each{|j|
+      RbIssueHistory.connection.select_all("select id, issue_id, property, timestamp, value from rb_journals where issue_id=#{issue.id}").sort{|a,b| a['timestamp'] <=> b['timestamp']}.each{|j|
         j['timestamp'] = Time.parse(j['timestamp']) if j['timestamp'].is_a?(String)
         date = j['timestamp'].to_date
         full_journal[date] ||= {}

--- a/app/models/rb_sprint_burndown.rb
+++ b/app/models/rb_sprint_burndown.rb
@@ -79,7 +79,7 @@ class RbSprintBurndown < ActiveRecord::Base
     # if I use self.version.id I get a "stack level too deep?!
     sprint = self.version # RbSprint.find(self.version_id)
 
-    if !sprint.has_burndown?
+    if sprint.nil? || !sprint.has_burndown?
       @_burndown = nil
     else
       @_burndown = {}


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.5, 2.2.0
backlogs:  # supported: 0.9.32
ruby:  # supported: 1.9.3, 1.8.7

I had to change execute to select_all and use explicit fields enumeration in the SELECT as otherwise connection returns an array of Mysql2::Result instead of array of hashes.
Also, fixed a 'nil-dereference'
