### PR TITLE
038 (issue rebuild) migration performance improvement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "open-uri-cached"
 gem "prawn"
 gem 'json'
 gem "system_timer" if RUBY_VERSION =~ /^1\.8\./ && RUBY_PLATFORM =~ /darwin|linux/
+gem "activerecord-import", ">= 0.2.0"
 
 group :development do
   gem "inifile"

--- a/app/models/rb_sprint_burndown.rb
+++ b/app/models/rb_sprint_burndown.rb
@@ -29,6 +29,12 @@ class RbSprintBurndown < ActiveRecord::Base
     self.save!
   end
 
+  def add_story(story_id)
+    story_id = Integer(story_id)
+    return if self.stories.include?(story_id)
+    self.stories << story_id
+  end
+
 #  This causes a recursive call to recalculate. I don't know why yet
 #  def [](key)
 #    self.recalculate!
@@ -70,7 +76,7 @@ class RbSprintBurndown < ActiveRecord::Base
     self.direction = Backlogs.setting[:points_burn_direction]
   end
 
-  def burndown
+  def burndown(do_save = true, issue2history = nil)
     return @_burndown if defined?(@_burndown)
 
     @_burndown = read_attribute(:burndown)
@@ -79,7 +85,7 @@ class RbSprintBurndown < ActiveRecord::Base
     # if I use self.version.id I get a "stack level too deep?!
     sprint = self.version # RbSprint.find(self.version_id)
 
-    if !sprint.has_burndown?
+    if sprint.nil? || !sprint.has_burndown?
       @_burndown = nil
     else
       @_burndown = {}
@@ -89,7 +95,7 @@ class RbSprintBurndown < ActiveRecord::Base
       statuses = RbIssueHistory.statuses
 
       RbStory.find(:all, :conditions => ['id in (?)', self.stories]).each{|story|
-        bd = story.burndown(sprint, statuses)
+        bd = story.burndown(sprint, statuses, issue2history)
         next unless bd
         bd.each_pair {|k, data|
           data.each_with_index{|d, i|
@@ -123,7 +129,7 @@ class RbSprintBurndown < ActiveRecord::Base
 
     cur = read_attribute(:burndown)
     write_attribute(:burndown, @_burndown)
-    self.save if @_burndown != cur
+    self.save if @_burndown != cur && do_save
     return @_burndown
   end
 end

--- a/app/models/rb_story.rb
+++ b/app/models/rb_story.rb
@@ -301,14 +301,15 @@ class RbStory < Issue
     return rl
   end
 
-  def burndown(sprint = nil, status=nil)
+  def burndown(sprint = nil, status=nil, issue2history = nil)
     return nil unless self.is_story?
+    issue2history = lambda{|i| i.history } if issue2history.nil?
     sprint ||= self.fixed_version.becomes(RbSprint) if self.fixed_version
     return nil if sprint.nil? || !sprint.has_burndown?
 
     bd = {:points_committed => [], :points_accepted => [], :points_resolved => [], :hours_remaining => []}
 
-    self.history.filter(sprint, status).each{|d|
+    issue2history.call(self).filter(sprint, status).each{|d|
       if d.nil? || d[:sprint] != sprint.id || d[:tracker] != :story
         [:points_committed, :points_accepted, :points_resolved, :hours_remaining].each{|k| bd[k] << nil}
       else


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.2
backlogs:  # supported: 1.0.5
ruby:  # supported: 1.9.3, 2.0.0

038 migration is pretty slow because in it a lot of work is made in individual INSERT/UPDATE queries. However, this migration seems to actually just add data to rb_sprint_burndown and rb_issue_history, so it's much faster to insert them in a bulk and don't do UPDATEs at all.

This is the main idea of the fix. To implement it, I had to evade calling issue.history everywhere because it momentarily makes an INSERT. Also, all calculations are made first (in memory), and only then data is inserted.

Besides this, some redundant SELECT and SHOW TABLES queries were removed.
It still can be improved, however (still too much queries), but it takes now 860 seconds on my DB versus more than 9000 seconds for initial implementation in v0.9.32 tag.

This approach has a possible downside: as associations are maintained manually, if Ruby code changes in the future, it can break this migration logic.
