### PR TITLE
Added missing french translations and cleanup

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -203,4 +203,4 @@ fr:
   label_filter_tasks_my_tasks: Filtrer par utilisateur - mes tâches
   label_all_tasks: Toutes les tâches
   label_my_tasks: Mes tâches
-  label_view_options: Options d'affichage
+  label_view_options: Options affichage


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.6, 2.2.2
backlogs:  # supported: 0.9.35
ruby:  # supported: 1.9.3, 1.8.7
