### PR TITLE
Fix images in tooltips.

### DIFF
--- a/app/helpers/rb_common_helper.rb
+++ b/app/helpers/rb_common_helper.rb
@@ -109,10 +109,6 @@ filter:progid:DXImageTransform.Microsoft.Gradient(Enabled=1,GradientType=0,Start
     story.new_record? ? "" : h(story.description).gsub(/&lt;(\/?pre)&gt;/, '<\1>')
   end
 
-  def textile_to_html(textile)
-    textile.nil? ? "" : Redmine::WikiFormatting::Textile::Formatter.new(textile).to_html
-  end
-
   def tracker_id_or_empty(story)
     story.new_record? ? "" : story.tracker_id
   end
@@ -215,7 +211,7 @@ filter:progid:DXImageTransform.Microsoft.Gradient(Enabled=1,GradientType=0,Start
       el = User.current
       s << "<option value=\"#{el.id}\" color=\"#{el.backlogs_preference[:task_color]}\" color_light=\"#{el.backlogs_preference[:task_color_light]}\">&lt;&lt; #{l(:label_me)} &gt;&gt;</option>"
     end
-    
+
     collection.sort.each do |element|
       if element.is_a?(Group)
         groups << "<option value=\"#{element.id}\" color=\"#AAAAAA\" color_light=\"#E0E0E0\">#{h element.name}</option>"

--- a/app/views/rb_stories/_tooltip.html.erb
+++ b/app/views/rb_stories/_tooltip.html.erb
@@ -9,5 +9,6 @@
 <b><%= I18n.t :field_assigned_to %></b>: <%=h assignee_name_or_empty(tooltip) %><br />
 <b><%= I18n.t :field_project %></b>: <%=h project_name_or_empty(tooltip) %><br />
 <b><%= I18n.t :field_release %></b>: <%=h release_or_empty(tooltip) %><br />
-<p><b><%= I18n.t :story_description %></b><br /><%=raw tidy(textile_to_html(tooltip.description)) %></p>
+<div><%= textilizable tooltip, :description, :attachments => tooltip.attachments%></div>
+
 <%=h custom_fields_or_empty(tooltip) %>


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.6, 2.2.3
backlogs:  # supported: 0.9.35
ruby:  # supported: 1.9.3, 1.8.7

Previously, images that were placed inline within a story's description would not display in the tooltips (they would show "broken" images).
