### PR TITLE
Fix a crash on the config page if the git binary wasn't on the PATH.

### DIFF
--- a/lib/backlogs_setup.rb
+++ b/lib/backlogs_setup.rb
@@ -22,8 +22,7 @@ module Backlogs
     if File.directory?(git)
       Dir.chdir(root)
       g = `git describe --tags --abbrev=10`
-      g.strip!
-      g = "(#{g})"
+      g = "(#{g.strip})" if g
     end
 
     v = [v, g].compact.join(' ')


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.6, 2.2.3
backlogs:  # supported: 0.9.35
ruby:  # supported: 1.9.3, 1.8.7
