### PR TITLE
fix. sprint's story don't reflect to move to top or bottom, when enable auto-refresh.

### DIFF
--- a/assets/javascripts/story.js
+++ b/assets/javascripts/story.js
@@ -105,12 +105,25 @@ RB.Story = RB.Object.create(RB.Issue, RB.EditableInplace, {
     var url;
     var j = this.$;
     var nxt = this.$.next();
+    var prv = this.$.prev();
     var sprint_id = this.$.parents('.backlog').data('this').isSprintBacklog() ? 
                     this.$.parents('.backlog').data('this').getSprint().data('this').getID() : '';
     var release_id = this.$.parents('.backlog').data('this').isReleaseBacklog() ? 
                     this.$.parents('.backlog').data('this').getRelease().data('this').getID() : '';
-    var data = "next=" + (nxt.length==1 ? this.$.next().data('this').getID() : '') +
-               "&fixed_version_id=" + sprint_id;
+    var data = "";
+    // move_to_top
+    if(prv.length != 1) {
+      data = "prev=";
+    } else if(nxt.length != 1 && prv.length == 1) {
+      // move_to_bottom
+      data = "prev=" + prv.data('this').getID();
+    } else {
+      // move_before
+      data = "next=" + nxt.data('this').getID();
+    }
+
+    data += "&fixed_version_id=" + sprint_id;
+
     if (release_id || !sprint_id) { /* when not sprint_id, issue goes to backlog, so remove release */
       data += "&release_id=" + release_id;
     }


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.6, 2.2.3
backlogs:  # supported: 0.9.36
ruby:  # supported: 1.9.3, 1.8.7

fix. sprint's story don't reflect to move to top or bottom, when enable auto-refresh.

@see https://github.com/backlogs/redmine_backlogs/blob/b292e36fb86fa9c408352c8903244a31f148c329/app/models/rb_story.rb#L241
