### PR TITLE
ruby 1.8 hash.keys are not ordered, they need sort

### DIFF
--- a/app/models/rb_issue_history.rb
+++ b/app/models/rb_issue_history.rb
@@ -65,7 +65,7 @@ class RbIssueHistory < ActiveRecord::Base
 #    limits = [nil,days[0..-2]].flatten
 limits = [nil] * days.size
     # Limit search to history of story
-    hist_limit = h.keys[0]
+    hist_limit = h.keys.sort[0] # hashes are ordered in ruby 1.9. They are not ordered in 1.8.
     filtered = days.each_with_index.collect{|d,i|
       #FIXME why did self.expand not give us all days in h?
       while !h[d] && (limits[i].nil? || d > limits[i]) && d > hist_limit


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.6, 2.2.3
backlogs:  # supported: 0.9.36
ruby:  # supported: 1.9.3, 1.8.7
