### PR TITLE
fix rb_application_controller not_configure render path error

### DIFF
--- a/app/controllers/rb_application_controller.rb
+++ b/app/controllers/rb_application_controller.rb
@@ -34,7 +34,7 @@ class RbApplicationController < ApplicationController
     @settings = Backlogs.settings
     if @settings[:story_trackers].blank? || @settings[:task_tracker].blank?
       respond_to do |format|
-        format.html { render :file => "shared/not_configured" }
+        format.html { render :file => "backlogs/not_configured" }
       end
     end
   end


### PR DESCRIPTION
platform:  # supported: 2.0.4, 2.1.6, 2.2.3
backlogs:  # supported: 0.9.36
ruby:  # supported: 1.9.3, 1.8.7
