### PR TITLE
Add missing release name/id to XML and JSON output of issues controller

### DIFF
--- a/lib/backlogs_issues_controller_patch.rb
+++ b/lib/backlogs_issues_controller_patch.rb
@@ -11,7 +11,7 @@ module Backlogs
 
       base.class_eval do
         unloadable # Send unloadable so it will not be unloaded in development
-        after_filter :add_backlogs_fields, :only => [:index]
+        after_filter :add_backlogs_fields, :only => [:index, :show]
       end
     end
 


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.0
backlogs:  # supported: 0.9.38
ruby:  # supported: 1.9.3, 2.0.0

See http://forum.redminebacklogs.net/Release-field-not-showing-up-in-XML-td4025721.html
