### PR TITLE
update config/locales/de.yml to correct small typo in german translation...

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -33,7 +33,7 @@ de:
   backlogs_sharing_support: Backlogs sharing
   backlogs_show_in_scrum_stats: Zeige das Projekt in der Scrumstatistik an
   backlogs_show_redmine_std_header: Zeige den regulären Header an
-  backlogs_show_stories_from_subprojects_in_backlog: Zeige Stories von Unterprojecten
+  backlogs_show_stories_from_subprojects_in_backlog: Zeige Stories von Unterprojekten
     im Backlog
   backlogs_sprint_card_settings: Sprintkarten drucken
   backlogs_sprint_sort_order: Sortiere Sprints


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.1
backlogs:  # supported: 1.0.1
ruby:  # supported: 1.9.3, 2.0.0

.... Affects #905
