### PR TITLE
Fix for JSON export of issues #918

### DIFF
--- a/lib/backlogs_issues_controller_patch.rb
+++ b/lib/backlogs_issues_controller_patch.rb
@@ -36,7 +36,7 @@ module Backlogs
           when 'json'
             jsonp = (request.params[:callback] || request.params[:jsonp]).to_s.gsub(/[^a-zA-Z0-9_]/, '')
             body = JSON.parse(jsonp.present? ? response.body.sub("#{jsonp}(","").chop : response.body)
-            body['issues'].each{|issue|
+            (body['issues'] || [body['issue']]).each{|issue|
               next unless story_trackers.include?(issue['tracker']['id'])
               issue['story_points'] = RbStory.find(issue['id']).story_points
               next unless RbStory.find(issue['id']).release


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.1
backlogs:  # supported: 1.0.1
ruby:  # supported: 1.9.3, 2.0.0
