### PR TITLE
Fix the problem with the JSON API when returning a single issue

### DIFF
--- a/lib/backlogs_issues_controller_patch.rb
+++ b/lib/backlogs_issues_controller_patch.rb
@@ -36,7 +36,11 @@ module Backlogs
           when 'json'
             jsonp = (request.params[:callback] || request.params[:jsonp]).to_s.gsub(/[^a-zA-Z0-9_]/, '')
             body = JSON.parse(jsonp.present? ? response.body.sub("#{jsonp}(","").chop : response.body)
-            body['issues'].each{|issue|
+            issuelist = body['issues']
+            if issuelist == nil 
+              issuelist = [body['issue']]
+            end
+            issuelist.each{|issue|
               next unless story_trackers.include?(issue['tracker']['id'])
               issue['story_points'] = RbStory.find(issue['id']).story_points
               next unless RbStory.find(issue['id']).release


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.1
backlogs:  # supported: 1.0.1
ruby:  # supported: 1.9.3, 2.0.0

I ran into this 

http://forum.redminebacklogs.net/NoMethodError-when-trying-to-get-issues-in-JSON-format-td4025760.html

(I'm not this person)

This is caused by calls to the API that only return a single issue. It works fine for XML because it uses the //issue selector, but JSON has no such thing - when a single issue is returned, it's the top level container, and not a list, so it has no each method.

This patch conditionally wraps such single issue returns in an array so they can be iterated over.
