### PR TITLE
Issue #27130 : default story tracker

### DIFF
--- a/app/views/backlogs/_settings.html.erb
+++ b/app/views/backlogs/_settings.html.erb
@@ -74,6 +74,10 @@
 <p>
   <%= content_tag(:label, l(:backlogs_story_tracker)) %>
   <%= select_tag("settings[story_trackers]", options_from_collection_for_select(Tracker.all, :id, :name, RbStory.trackers), :multiple => true) %>
+  <br />
+  <%= content_tag(:label, l(:backlogs_default_story_tracker)) %>
+  <%= select_tag("settings[default_story_tracker]", options_from_collection_for_select(Tracker.all, :id, :name, Backlogs.setting[:default_story_tracker])) %>
+  
   <table>
     <thead>
       <tr>

--- a/app/views/rb_stories/_helpers.html.erb
+++ b/app/views/rb_stories/_helpers.html.erb
@@ -15,7 +15,11 @@
 
 <select class="tracker_id helper" id="tracker_id_options">
   <%- RbStory.trackers(:project => @project, :type => :trackers).each do |tracker| %>
-  <option value="<%= tracker.id %>"><%= h tracker.name %></option>
+	  <%- if (Backlogs.settings[:default_story_tracker] && tracker.id.to_s==Backlogs.settings[:default_story_tracker]) %>
+	  <option value="<%= tracker.id %>" selected="selected"><%= h tracker.name %></option>
+	  <%- else %>
+	  <option value="<%= tracker.id %>"><%= h tracker.name %></option>
+	  <%- end %>
   <%- end %>
 </select>
 

--- a/assets/javascripts/model.js
+++ b/assets/javascripts/model.js
@@ -119,6 +119,9 @@ RB.Model = RB.Object.create({
       
       // Copy the value in the field to the input element
       value = ( fieldType=='select' ? field.children('.v').first().text() : RB.$.trim(field.text()) );
+      if ((fieldType=='select') && input.children("option[selected='selected']")) {
+    	  value = input.children("option[selected='selected']:first").val();
+      }
       input.val(value);
       
       // Record in the model's root element which input field had the last focus. We will

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -94,6 +94,7 @@ de:
   backlogs_story_follows_task_status: Status der Story wird von der Aufgabe abgeleitet
   backlogs_story_settings: Story und Task Einstellungen
   backlogs_story_tracker: Story Tracker
+  backlogs_default_story_tracker: Standard Story Tracker
   backlogs_task: Aufgabe
   backlogs_task_tracker: Aufgaben Tracker
   backlogs_wiki_template: Vorlage für das Sprint-Wiki

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
   backlogs_sprints: Sprints
   backlogs_story: Story
   backlogs_story_tracker: Story trackers
+  backlogs_default_story_tracker: Default story tracker
   backlogs_task: Task
   backlogs_task_tracker: Task tracker
   backlogs_wiki_template: Template for sprint wiki page

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -91,6 +91,7 @@ fr:
   backlogs_story_follows_task_status: Story suit le statut de tâche
   backlogs_story_settings: Préférences de Story/Tâches
   backlogs_story_tracker: Tracker de stories
+  backlogs_default_story_tracker: Tracker défaut de stories
   backlogs_task: Tâches
   backlogs_task_tracker: Tracker de tâches
   backlogs_wiki_template: Maquette pour page wiki des sprints

--- a/init.rb
+++ b/init.rb
@@ -56,6 +56,7 @@ Redmine::Plugin.register :redmine_backlogs do
 
   settings :default => {
                          :story_trackers            => nil,
+                         :default_story_tracker     => nil,
                          :task_tracker              => nil,
                          :card_spec                 => nil,
                          :story_close_status_id     => '0',


### PR DESCRIPTION
platform: 2.3.1 supported: 2.2.4, 2.3.1 # supported: 2.2.4, 2.3.1
backlogs: 1.0.3 supported: 1.0.3 # supported: 1.0.3
ruby: 1.9.3 supported: 1.9.3, 2.0.0 # supported: 1.9.3, 2.0.0

Hi,

we have multiple story trackers here (called Story and Bug) but prefer one (Story). Unfortunately Bug is always preselected when a new story is created on the master backlogs page.

The following change creates a new setting on the backlogs configuration page to choose a default story tracker.
