### PR TITLE
added tests for the default story tracker

### DIFF
--- a/features/product_owner.feature
+++ b/features/product_owner.feature
@@ -42,6 +42,28 @@ Feature: Product Owner
      When I create the story
      Then the request should complete successfully
       And the 1st story in the product backlog should be A Whole New Story
+      
+  Scenario: Create a new default story
+    Given I am viewing the master backlog
+      And I add the tracker Bug to the story trackers
+      And I set the default story tracker to Story
+      And I want to create a story
+      And I set the subject of the story to A default Story
+     When I create the story
+     Then the request should complete successfully
+      And the 1st story in the product backlog should be A default Story
+      And the 1st story in the product backlog should have the tracker Story
+      
+  Scenario: Create a new default bug
+    Given I am viewing the master backlog
+      And I add the tracker Bug to the story trackers
+      And I set the default story tracker to Bug
+      And I want to create a story
+      And I set the subject of the story to A default Bug
+     When I create the story
+     Then the request should complete successfully
+      And the 1st story in the product backlog should be A default Bug
+      And the 1st story in the product backlog should have the tracker Bug
 
   Scenario: Update a story
     Given I am viewing the master backlog

--- a/features/step_definitions/_given_steps.rb
+++ b/features/step_definitions/_given_steps.rb
@@ -104,6 +104,17 @@ Given /^I set the (.+) of the task to (.+)$/ do |attribute, value|
   @task_params[attribute] = value
 end
 
+Given /^I add the tracker (.+) to the story trackers$/ do |tracker|
+  tracker_id = Tracker.find(:first, :conditions=>{:name => tracker}).id
+  @project.update_attribute :tracker_ids, (@project.tracker_ids << tracker_id)
+  Backlogs.setting[:story_trackers] << tracker_id
+end
+  
+Given /^I set the default story tracker to (.+)$/ do |tracker|
+  t = get_tracker(tracker)
+  Backlogs.setting[:default_story_tracker] = t.id
+end
+
 Given /^I want to create a story$/ do
   @story_params = initialize_story_params
 end

--- a/features/step_definitions/_then_steps.rb
+++ b/features/step_definitions/_then_steps.rb
@@ -150,6 +150,16 @@ Then /^the (\d+)(?:st|nd|rd|th) story in (.+) should be (.+)$/ do |position, bac
   story.subject.should == subject
 end
 
+Then /^the (\d+)(?:st|nd|rd|th) story in (.+) should have the tracker (.+)$/ do |position, backlog, tracker|
+  sprint = (backlog == 'the product backlog' ? nil : Version.find_by_name(backlog))
+  story = RbStory.find_by_rank(position.to_i, RbStory.find_options(:project => @project, :sprint => sprint))
+  
+  t = get_tracker(tracker)
+  
+  story.should_not be_nil
+  story.tracker.should == t
+end
+
 Then /^the (\d+)(?:st|nd|rd|th) task for (.+) should be (.+)$/ do |position, story_subject, task_subject|
   story = RbStory.find(:first, :conditions => ["subject=?", story_subject])
   story.should_not be_nil

--- a/features/step_definitions/helpers.rb
+++ b/features/step_definitions/helpers.rb
@@ -52,6 +52,10 @@ def get_project(identifier)
   Project.find(identifier)
 end
 
+def get_tracker(identifier)
+  Tracker.find_by_name(identifier)
+end
+
 
 def current_sprint(name = nil)
   if name.is_a?(Symbol)
@@ -156,7 +160,7 @@ end
 def initialize_story_params(project_id = nil)
   @story = HashWithIndifferentAccess.new(RbStory.new.attributes)
   @story['project_id'] = project_id ? Project.find(project_id).id : @project.id
-  @story['tracker_id'] = RbStory.trackers.first
+  @story['tracker_id'] = RbStory.trackers.include?(Backlogs.setting[:default_story_tracker]) ? Backlogs.setting[:default_story_tracker] : RbStory.trackers.first 
   @story['author_id']  = @user.id
   @story
 end


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.1
backlogs:  # supported: 1.0.3
ruby:  # supported: 1.9.3, 2.0.0

Took some time as I was struggling to set up the tests. I hope this is okay.
