### PR TITLE
Now you can filter closed stories in taskboard view

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -44,6 +44,7 @@
   <li><label>
     <select class="userfilter" size="5" name="filter-user-selection" multiple="multiple" title="User selection">
       <option value='s'>Show empty Stories</option>
+      <option value='c'>Show closed Stories</option>
       <optgroup label="Users">
       <% @project.assignable_users.sort.each do |member| %>
         <option value="<%= member.id %>"> <%= member.name %></option>

--- a/assets/javascripts/taskboard.js
+++ b/assets/javascripts/taskboard.js
@@ -253,11 +253,14 @@ RB.UserFilter = RB.Object.create({
   updateStories: function() {
     //Check if all stories should be visible even if not used
     var showUnusedStories = this.el.multiselect("widget").find(":checkbox[value='s']").is(':checked');
+    var showClosedStories = this.el.multiselect("widget").find(":checkbox[value='c']").is(':checked');
 
     //Parse through all the stories and hide the ones not used
     RB.$('.story').each(function() {
       var sprintInfo = RB.$(this).children('.id').children('a')[0];
       var storyID = sprintInfo.innerHTML;
+
+      var isClosed = RB.$(this).hasClass('closed');
 
       RB.$(this).closest('tr').show();
       var hasVisTasks = 0;
@@ -273,7 +276,7 @@ RB.UserFilter = RB.Object.create({
       });
 
       //Hide or show story row based on if any tasks are visible
-      if (hasVisTasks || (showUnusedStories && !hasTasks))
+      if ((hasVisTasks || (showUnusedStories && !hasTasks)) && (showClosedStories || !isClosed))
         RB.$(this).closest('tr').show();
       else
         RB.$(this).closest('tr').hide();


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.2
backlogs:  # supported: 1.0.5
ruby:  # supported: 1.9.3, 2.0.0

There are moments you want to see only open stories. In this way, you clearly see how much pending work your team have. I think is a cool feature.
