### PR TITLE
Update de.yml

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -26,7 +26,7 @@ de:
   backlogs_sharing_enabled: "Sharing aktivieren"
   backlogs_sharing_new_sprint: "Neue Sprints teilen"
   backlogs_sharing_new_sprint_explanation: "Obwohl hier alle Einstellungen verfügbar sind, werden die Rechte für neue Sprints entsprechend der Rollen der Benutzer im Projekt berücksichtigt. Übergreifend geteilte Sprints können nur durch Administratoren erstellt werden. In einer Hierarchie- oder Baumstruktur geteilte Sprints benötigen die notwendigen Rechte des Wurzelprojekts."
-  backlogs_sharing_support: "Backlogs sharing"
+  backlogs_sharing_support: "Projektübergreifende Backlogs"
   backlogs_show_in_scrum_stats: "Zeige das Projekt in der Scrumstatistik an"
   backlogs_show_priority: "Show task priority on taskboard"
   backlogs_show_redmine_std_header: "Zeige den regulären Header an"


### PR DESCRIPTION
platform:  # supported: 2.2.4, 2.3.2
backlogs:  # supported: 1.0.5
ruby:  # supported: 1.9.3, 2.0.0

Please merge this minor update for German translation.
The remaining 3 labels field_tracker_id. label_master_backlog, label_release_plural listed on http://www.redminebacklogs.net/en/translations.html are OK and should not be translated.
