### PR TITLE
Fix not showing link to task board if sprint starts on current day

### DIFF
--- a/lib/backlogs_project_patch.rb
+++ b/lib/backlogs_project_patch.rb
@@ -233,9 +233,10 @@ module Backlogs
       end
 
       def active_sprint
+        time = (Time.zone ? Time.zone : Time).now
         @active_sprint ||= RbSprint.find(:first, :conditions => [
-          "project_id = ? and status = 'open' and not (sprint_start_date is null or effective_date is null) and ? between sprint_start_date and effective_date",
-          self.id, (Time.zone ? Time.zone : Time).now.beginning_of_day
+          "project_id = ? and status = 'open' and not (sprint_start_date is null or effective_date is null) and ? >= sprint_start_date and ? <= effective_date",
+          self.id, time.end_of_day, time.beginning_of_day
         ])
       end
 


### PR DESCRIPTION
The use of between for the start and end date means that if the current date == the starting date, the current sprint will not be selected as active.

This fix changes the comparison so that the end of the current day is compared with the start date and the beginning of the current day is compared with the end day.
