### PR TITLE
No longer removes search field

### DIFF
--- a/app/views/layouts/rb.html.erb
+++ b/app/views/layouts/rb.html.erb
@@ -63,7 +63,7 @@ RB.$(function(){
 <div id="header">
     <% if User.current.logged? || !Setting.login_required? %>
     <div id="quick-search">
-        <% form_tag({:controller => 'search', :action => 'index', :id => @project}, :method => :get ) do %>
+        <%= form_tag({:controller => 'search', :action => 'index', :id => @project}, :method => :get ) do %>
         <%= hidden_field_tag(controller.default_search_scope, 1, :id => nil) if controller.default_search_scope %>
         <label for='q'>
           <%= link_to l(:label_search), {:controller => 'search', :action => 'index', :id => @project}, :accesskey => accesskey(:search) %>:


### PR DESCRIPTION
Currently the search bar is not shown when viewing any backlogs tab.  This appears to be due to a missing '=' sign in the layout erb file.

If this is intentional, feel free to ignore this pull request.
