### PR TITLE
Replace storypoints text_field with select at new issue/edit issue page

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -119,7 +119,11 @@ module BacklogsPlugin
           if issue.is_story?
             snippet += '<p>'
             #snippet += context[:form].label(:story_points)
-            snippet += context[:form].select(:story_points, options_for_select(Backlogs.setting[:story_points].split(',').map(&:to_i), issue.story_points.try(:to_i).try(:to_s)), include_blank: true)
+            if Backlogs.setting[:story_points].blank?
+              snippet += context[:form].text_field(:story_points, :size => 3)
+            else
+              snippet += context[:form].select(:story_points, options_for_select(Backlogs.setting[:story_points].split(',').map(&:to_i), issue.story_points.try(:to_i).try(:to_s)), include_blank: true)
+            end
             snippet += '</p>'
 
             if issue.safe_attribute?('release_id') && issue.assignable_releases.any?


### PR DESCRIPTION
When creating new issue or editing issue, user can add/edit storypoints. The problem is he is able to assign storypoints different from these defined at plugin configuration page (as well as these available on backlogs page of project).

So here's my solution to it - simply replace text input with select with options consistent with storypoints set on plugin setting page (and blank option inlucuded).

Hope I didnt mess anything up.. thats my first pull request ;)
