### PR TITLE
feature: display due dates for stories in backlog sprints

### DIFF
--- a/app/helpers/rb_master_backlogs_helper.rb
+++ b/app/helpers/rb_master_backlogs_helper.rb
@@ -58,4 +58,8 @@ module RbMasterBacklogsHelper
   def stories(backlog)
     backlog[:stories] || backlog.stories
   end
+
+  def due_date_enabled?
+    Backlogs.setting[:show_due_date]
+  end
 end

--- a/app/views/backlogs/_settings.html.erb
+++ b/app/views/backlogs/_settings.html.erb
@@ -77,7 +77,7 @@
   <br />
   <%= content_tag(:label, l(:backlogs_default_story_tracker)) %>
   <%= select_tag("settings[default_story_tracker]", options_from_collection_for_select(Tracker.all, :id, :name, Backlogs.setting[:default_story_tracker])) %>
-  
+
   <table>
     <thead>
       <tr>
@@ -168,7 +168,7 @@
   <br />
   <span>
   <%= content_tag(:label, l(:backlogs_story_close_status)) %>
-  <%= select_tag("settings[story_close_status_id]", 
+  <%= select_tag("settings[story_close_status_id]",
             options_for_select([['<'+l(:rb_label_timelog_disable)+'>', 0]] + IssueStatus.all.collect{|e| [e.name, e.id]},
                               Setting.plugin_redmine_backlogs.has_key?(:story_close_status_id)?(Setting.plugin_redmine_backlogs[:story_close_status_id].to_i):0)
   ) %>
@@ -285,6 +285,11 @@
   <%= content_tag(:label, l(:rb_show_project_name)) %>
   <%= check_box_tag("settings[show_project_name]",'enabled',
             Backlogs.setting[:show_project_name]) %>
+</p>
+<p>
+  <%= content_tag(:label, l(:rb_show_due_date)) %>
+    <%= check_box_tag("settings[show_due_date]",'enabled',
+            Backlogs.setting[:show_due_date]) %>
 </p>
 </fieldset>
 

--- a/app/views/rb_stories/_story.html.erb
+++ b/app/views/rb_stories/_story.html.erb
@@ -22,7 +22,14 @@
     <div class="v"><%= tracker_id_or_empty(story) %></div>
   </div>
  </div>
- <div class="fff-right">
+ <div class= <%= due_date_enabled? ? 'fff-right-wide' : 'fff-right' %>>
+  <% if due_date_enabled? %>
+   <div class='due_date story_field'>
+    <% if story.due_date %>
+     <div>due date: <%= story.due_date %></div>
+    <% end %>
+   </div>
+  <% end %>
   <div class="status_id editable story_field" fieldtype="select" fieldname="status_id" fieldlabel="<%=l(:field_status_id)%>">
     <div class="t"><%= status_label_or_default(story) %></div>
     <div class="v"><%= status_id_or_default(story) %></div>

--- a/assets/stylesheets/master_backlog.css
+++ b/assets/stylesheets/master_backlog.css
@@ -2,7 +2,7 @@
  * reserved classes are
  * .backlog (used in master_backlog.js to initialize all backlogs)
  * .model (used in backlog.js editable_inplace.js model.js)
- * .sprint (used in backlog.js 
+ * .sprint (used in backlog.js
  * .stories (used in backlog.js for sortable)
  * .editor
  * .editable (bind click on)
@@ -286,7 +286,7 @@ ul li { vertical-align: bottom; } /* close IE7 gap between list items */
 .header .date{
   height:28px;
   line-height:28px;
-  white-space: nowrap; 
+  white-space: nowrap;
   font-size:12px;
 }
 
@@ -710,3 +710,17 @@ ul li { vertical-align: bottom; } /* close IE7 gap between list items */
 
 /* show completed sprints */
 #show_completed_sprints { cursor:pointer; }
+
+/*due date additions*/
+#backlogs_container .stories .story .due_date {
+  width:130px;
+  float:left;
+  padding-left: 8px;
+  white-space: nowrap;
+}
+
+.fff-right-wide {
+  float: left;
+  width: 250px;
+  margin-left: -250px;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,7 @@ en:
   rb_release_burnup_enabled: "Enable release burnup chart (EXPERIMENTAL)"
   rb_show_burndown_in_sidebar: "Show burndown chart in issues sidebar"
   rb_show_project_name: "Show project name in backlogs"
+  rb_show_due_date: "Show due date for sprint stories"
   rb_task_cards_stories_then_tasks: "First all stories, then all tasks"
   rb_task_cards_story_follows_tasks: "Tasks followed by their story"
   rb_task_cards_tasks_follow_story: "Story followed by their tasks"

--- a/init.rb
+++ b/init.rb
@@ -64,6 +64,7 @@ Redmine::Plugin.register :redmine_backlogs do
                          :story_points              => "1,2,3,5,8",
                          :show_burndown_in_sidebar  => 'enabled',
                          :show_project_name         => nil,
+                         :show_due_date             => nil,
                          :scrum_stats_menu_position => 'top',
                          :show_redmine_std_header   => 'enabled',
                          :show_priority             => nil
@@ -153,13 +154,13 @@ Redmine::Plugin.register :redmine_backlogs do
   menu :project_menu, :rb_releases, { :controller => :rb_releases, :action => :index }, :caption => :label_release_plural, :after => :rb_taskboards, :param => :project_id, :if => Proc.new { Backlogs.configured? }
 
   menu :top_menu, :rb_statistics, { :controller => :rb_all_projects, :action => :statistics}, :caption => :label_scrum_statistics,
-    :if => Proc.new { 
+    :if => Proc.new {
       Backlogs.configured? &&
       User.current.allowed_to?({:controller => :rb_all_projects, :action => :statistics}, nil, :global => true) &&
       (Backlogs.setting[:scrum_stats_menu_position].nil? || Backlogs.setting[:scrum_stats_menu_position] == 'top')
     }
   menu :application_menu, :rb_statistics, { :controller => :rb_all_projects, :action => :statistics}, :caption => :label_scrum_statistics,
-    :if => Proc.new { 
+    :if => Proc.new {
       Backlogs.configured? &&
       User.current.allowed_to?({:controller => :rb_all_projects, :action => :statistics}, nil, :global => true) &&
       Backlogs.setting[:scrum_stats_menu_position] == 'application'


### PR DESCRIPTION
It could be useful to see story due dates inside backlog sprints. Therefore I added such possibility. Due date is shown next to the story status. If story has no due date set, nothing is shown. You can enable/disable this functionality on backlogs settings page (with a checkbox just below `show project name in backlog`).

Sorry for messing with withespaces in few unintended places - that's because of my editor configuration. 
