### PR TITLE
Feature: Story follows task status - additional option.

### DIFF
--- a/app/views/backlogs/_settings.html.erb
+++ b/app/views/backlogs/_settings.html.erb
@@ -162,6 +162,9 @@
   <%= radio_button_tag("settings[story_follow_task_status]", 'close',
       Backlogs.setting[:story_follow_task_status] == 'close' ) %><%= l(:backlogs_story_follow_task_status_close) %>
   <br />
+  <%= radio_button_tag("settings[story_follow_task_status]", 'inprogress',
+      Backlogs.setting[:story_follow_task_status] == 'inprogress' ) %><%= "Resolved when all Tasks are closed.\n In Progress when even one Task is not new." %>
+  <br />
   <%= radio_button_tag("settings[story_follow_task_status]", 'loose',
       Backlogs.setting[:story_follow_task_status] == 'loose' ) %><%= l(:backlogs_story_follow_task_status_loose) %>
   <span id="settings_story_follow_task_status_explanation" style="display:block;margin-left:12px"><%= l(:backlogs_story_follows_task_loose_explanation) %></span>


### PR DESCRIPTION
I add some additional feature to backlogs 'Story follows task status' option which can be enabled/disabled on backlog settings page with a radio button described as "Resolved when all Tasks are closed. In Progress when even one Task is not new.". It works just like name says: if every task in story is closed, it changes story status to 'resolved'; also if even one task in not new (is not default) it changes story status to in progress.
