### PR TITLE
Only show visible updated items

### DIFF
--- a/app/controllers/rb_updated_items_controller.rb
+++ b/app/controllers/rb_updated_items_controller.rb
@@ -15,21 +15,21 @@ class RbUpdatedItemsController < RbApplicationController
 
     latest_updates = []
     if only.include? :stories
-      @items[:stories] = RbStory.find_all_updated_since(params[:since], @project.id)
+      @items[:stories] = RbStory.visible.find_all_updated_since(params[:since], @project.id)
       if @items[:stories].length > 0
         latest_updates << @items[:stories].sort{ |a,b| a.updated_on <=> b.updated_on }.last
       end
     end
 
     if only.include? :tasks
-      @items[:tasks] = RbTask.find_all_updated_since(params[:since], @project.id, false, params[:sprint])
+      @items[:tasks] = RbTask.visible.find_all_updated_since(params[:since], @project.id, false, params[:sprint])
       if @items[:tasks].length > 0
         latest_updates << @items[:tasks].sort{ |a,b| a.updated_on <=> b.updated_on }.last
       end
     end
 
     if only.include? :impediments
-      @items[:impediments] = RbTask.find_all_updated_since(params[:since], @project.id, true, params[:sprint])
+      @items[:impediments] = RbTask.visible.find_all_updated_since(params[:since], @project.id, true, params[:sprint])
       if @items[:impediments].length > 0
         latest_updates << @items[:impediments].sort{ |a,b| a.updated_on <=> b.updated_on }.last
       end

--- a/app/models/rb_release.rb
+++ b/app/models/rb_release.rb
@@ -190,7 +190,7 @@ class RbRelease < ActiveRecord::Base
   end
 
   def stories #compat
-    issues
+    issues.visible
   end
 
   # Returns current stories + stories previously scheduled for this release
@@ -217,7 +217,7 @@ class RbRelease < ActiveRecord::Base
     order = Backlogs.setting[:sprint_sort_order] == 'desc' ? 'DESC' : 'ASC'
 #return issues sorted into sprints. Obviously does not return issues which are not in a sprint
 #unfortunately, group_by returns unsorted results.
-    issues.where(:tracker_id => RbStory.trackers).joins(:fixed_version).includes(:fixed_version).order("versions.effective_date #{order}").group_by(&:fixed_version_id)
+    stories.where(:tracker_id => RbStory.trackers).joins(:fixed_version).includes(:fixed_version).order("versions.effective_date #{order}").group_by(&:fixed_version_id)
   end
 
   # The dates are:


### PR DESCRIPTION
Private issues are currently displayed via the backlog refresh mechanism.
