### PR TITLE
#1043: When assigning issues to a release, comment logs ID rather than name

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -13,6 +13,21 @@ module BacklogsPlugin
         Rails.logger.error "#{ex.message} (#{ex.class}): " + ex.backtrace.join("\n")
       end
 
+      def helper_issues_show_detail_after_setting(context={ })
+      	begin
+          if context[:detail].prop_key == 'release_id'
+            r = RbRelease.find_by_id(context[:detail].value)
+            context[:detail].value = r.name unless r.nil? || r.name.nil?
+
+            r = RbRelease.find_by_id(context[:detail].old_value)
+            context[:detail].old_value = r.name unless r.nil? || r.name.nil?
+          end
+        rescue => e
+          exception(context, e)
+          return ''
+        end
+      end
+
       def view_issues_sidebar_planning_bottom(context={ })
         begin
           return '' if User.current.anonymous?


### PR DESCRIPTION
Hook in to redmine to show the proper release name under the comments when assigning and moving between releases.
