### PR TITLE
Hide new story link if user does not have permission to create a new story on the subproject

### DIFF
--- a/app/controllers/rb_master_backlogs_controller.rb
+++ b/app/controllers/rb_master_backlogs_controller.rb
@@ -39,6 +39,7 @@ class RbMasterBacklogsController < RbApplicationController
       else #menu for product backlog
         projects = @project.projects_in_shared_product_backlog
       end
+      projects.select!{ |p| User.current.allowed_to?(:create_stories, p) }
       #make the submenu or single link
       if !projects.empty?
         if projects.length > 1


### PR DESCRIPTION
If a user attempts to create a story on a subproject where either:
1. The backlogs module is disabled
2. The user does not have permission to create a new story

The new dialog will still appear and a 403 error will result when the user attempts to create the story.  This change simply hides subprojects where the user does not have permission to create a new story from the drop down list.
