### PR TITLE
Removed deprecation warnings in newer rails.

### DIFF
--- a/app/controllers/rb_burndown_charts_controller.rb
+++ b/app/controllers/rb_burndown_charts_controller.rb
@@ -11,7 +11,7 @@ class RbBurndownChartsController < RbApplicationController
 
   def embedded
     respond_to do |format|
-      format.html { render :template => 'rb_burndown_charts/show.html.erb', :layout => false }
+      format.html { render :template => 'rb_burndown_charts/show', :layout => false, :formats => [:html], :handlers => [:erb] }
     end
   end
 

--- a/app/controllers/rb_hooks_render_controller.rb
+++ b/app/controllers/rb_hooks_render_controller.rb
@@ -13,7 +13,7 @@ class RbHooksRenderController < RbApplicationController
     }
 
     respond_to do |format|
-      format.html { render :template => 'backlogs/view_issues_sidebar.html.erb', :layout => false, :locals => locals }
+      format.html { render :template => 'backlogs/view_issues_sidebar', :layout => false, :locals => locals, :formats => [:html], :handlers => [:erb] }
     end
   end
 

--- a/app/controllers/rb_server_variables_controller.rb
+++ b/app/controllers/rb_server_variables_controller.rb
@@ -9,7 +9,7 @@ class RbServerVariablesController < RbApplicationController
     @context = params[:context]
     respond_to do |format|
       format.html { render_404 }
-      format.js { render :file => 'rb_server_variables/show.js.erb', :layout => false }
+      format.js { render :file => 'rb_server_variables/show', :formats => [:js], :handlers => [:erb], :layout => false }
     end
   end
 


### PR DESCRIPTION
As was reported in [Issue#793](https://github.com/backlogs/redmine_backlogs/issues/793), current version of rails will spam with following warnings:

```
DEPRECATION WARNING: Passing a template handler in the template name is deprecated. You can simply remove the handler name or pass render :handlers => [:erb]
```

This fixes it by dropping support for rails 2(it isn't needed anyway, as newer Redmine requires RoR 3.2+).
