### PR TITLE
Added check of view_time_entries-permission in taskboard-tooltips

### DIFF
--- a/app/views/rb_stories/_tooltip.html.erb
+++ b/app/views/rb_stories/_tooltip.html.erb
@@ -4,7 +4,7 @@
 <b><%= I18n.t :field_category %></b>: <%=h tooltip.category %><br />
 <b><%= I18n.t :story_points %></b>: <%=h story_points_or_empty(tooltip) %><br />
 <b><%= I18n.t :story_estimation_hours %></b>: <%=h tooltip.estimated_hours %><br />
-<b><%= I18n.t :story_spent_time %></b>: <%= tooltip.total_spent_hours.round(2) %><br />
+<% if User.current.allowed_to?(:view_time_entries, @project) %><b><%= I18n.t :story_spent_time %></b>: <%= tooltip.total_spent_hours.round(2) %><br /><% end %>
 <b><%= I18n.t :story_remaining_hours %></b>: <%=h remaining_hours_or_empty(tooltip) %><br />
 <b><%= I18n.t :field_assigned_to %></b>: <%=h assignee_name_or_empty(tooltip) %><br />
 <b><%= I18n.t :field_project %></b>: <%=h project_name_or_empty(tooltip) %><br />


### PR DESCRIPTION
Hey guys,

first of all thanks for your awesome work. We use redmine with backlogs on daily basis in our office.

Recently we noticed that users who are not allowed to see time entries were able to see the total spend time on tasks and stories by hovering over the tooltip. We fixed this in 0c2b8660fdc6544097891ce71444f8460bd01f91 and hope that you integrate this into the next version.

Best regards
Alex
