### PR TITLE
V1.0.6 taskboard optimization

### DIFF
--- a/app/helpers/rb_common_helper.rb
+++ b/app/helpers/rb_common_helper.rb
@@ -5,6 +5,7 @@ module RbCommonHelper
   unloadable
 
   include CustomFieldsHelper
+  include RbPartialsHelper
 
   def assignee_id_or_empty(story)
     story.new_record? ? "" : story.assigned_to_id

--- a/app/helpers/rb_partials_helper.rb
+++ b/app/helpers/rb_partials_helper.rb
@@ -9,11 +9,11 @@ module RbPartialsHelper
       erb_data = File.read(filename)
       eruby = Erubis::FastEruby.new(erb_data)
       eruby.def_method(self, method_name_and_args)
-      method_name = method_name_and_args[/^[^(]+/].strip
-      alias_method "_erb_of_#{method_name}", method_name
-      define_method method_name do |*args|
-        public_send("_erb_of_#{method_name}", *args).html_safe
+      method_name = method_name_and_args[/^[^(]+/].strip.to_sym
+      define_method "#{method_name}_with_html_safe" do |*args, &block|
+        send("#{method_name}_without_html_safe", *args, &block).html_safe
       end
+      alias_method_chain method_name, :html_safe
       method_name
     end
 

--- a/app/helpers/rb_partials_helper.rb
+++ b/app/helpers/rb_partials_helper.rb
@@ -1,0 +1,39 @@
+module RbPartialsHelper
+  unloadable
+
+  PLUGIN_VIEWS_PATH = File.expand_path('../../views', __FILE__)
+
+  class << self
+
+    def def_erb_method(method_name_and_args, filename)
+      erb_data = File.read(filename)
+      eruby = Erubis::FastEruby.new(erb_data)
+      eruby.def_method(self, method_name_and_args)
+      method_name = method_name_and_args[/^[^(]+/].strip
+      alias_method "_erb_of_#{method_name}", method_name
+      define_method method_name do |*args|
+        public_send("_erb_of_#{method_name}", *args).html_safe
+      end
+      method_name
+    end
+
+    def def_rb_partial_method(method_name_and_args, rb_partial_filename)
+      filename = File.expand_path(rb_partial_filename, PLUGIN_VIEWS_PATH)
+      def_erb_method(method_name_and_args, filename)
+    end
+
+  end
+
+
+  def_rb_partial_method 'render_rb_task(task)', 'rb_tasks/_task.html.erb'
+
+  def render_rb_task_collection(tasks)
+    capture do
+      tasks.each do |task|
+        concat render_rb_task(task)
+      end
+    end
+  end
+
+end
+

--- a/app/models/rb_story.rb
+++ b/app/models/rb_story.rb
@@ -434,6 +434,17 @@ class RbStory < Issue
         end
   end
 
+  def descendants(*args)
+    descendants = super
+    descendants.each do |issue|
+      next unless issue.is_task?
+      if self.id == (issue.parent_id || issue.parent_issue_id)
+        issue.instance_variable_set(:@rb_story, self)
+      end
+    end
+    descendants
+  end
+
 private
 
   def calc_total_auto(p,days,in_release_first)

--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -129,7 +129,7 @@
       </td>
       <%- @statuses.each do |status| %>
       <td class="swimlane list <%= status.is_closed? ? 'closed' : '' %>" id="<%= story.id %>_<%= status.id %>" -rb-status-id="<%= status.id %>" -rb-project-id="<%= story.project.id %>">
-        <%= render :partial => "rb_tasks/task", :collection => story.descendants.select{|task| task.status_id==status.id} %>
+        <%= render_rb_task_collection(story.descendants.select{|task| task.status_id==status.id}) %>
       </td>
       <%- end %>
     </tr>

--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -128,7 +128,7 @@
       </td>
       <%- @statuses.each do |status| %>
       <td class="swimlane list <%= status.is_closed? ? 'closed' : '' %>" id="<%= story.id %>_<%= status.id %>" -rb-status-id="<%= status.id %>" -rb-project-id="<%= story.project.id %>">
-        <%= render :partial => "rb_tasks/task", :collection => story.descendants.select{|task| task.status.id==status.id} %>
+        <%= render :partial => "rb_tasks/task", :collection => story.descendants.select{|task| task.status_id==status.id} %>
       </td>
       <%- end %>
     </tr>

--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -103,9 +103,10 @@
     <tr id="swimlane-<%= story.id %>" class="story-swimlane">
       <td>
         <div class="story <%= mark_if_closed(story) %>" <%= build_inline_style(story).html_safe %>>
-          <div class="id story_tooltip">
-            <div class="tooltip_text"><%= render :partial => "rb_stories/tooltip", :object => story %></div>
+          <div class="id story_tooltip_ajax">
+            <div class="tooltip_text"></div>
             <%= link_to story.id, {:controller => 'issues', :action => 'show', :id => story.id}, { :target => "_blank" } %>
+            <div class="v"><%= story.id %></div>
             <% if User.current.allowed_to?(:create_tasks, @project) %>
             <span class="add_new">
               <%= image_tag("add.png", :alt => "+") %>


### PR DESCRIPTION
This has cut off total about 40-50% of server side response time with a large sprint with number of stories+tasks exceeding 1000.

Changes are:
- unnecessary loading of status just to get id (`task.status.id` -> `task.status_id`) in app/views/rb_taskboards/show.html.erb
- eliminate loading of task's story when task is actually loaded as a descendant of that story. 
- switch to story_tooltip_ajax instead of rendering rb_stories/tooltip partial
- avoid repeated `render :partial => 'name'` which resolves the partial from name every time.
