### PR TITLE
Fixed ordering of releases in master backlogs view.

### DIFF
--- a/lib/backlogs_project_patch.rb
+++ b/lib/backlogs_project_patch.rb
@@ -245,14 +245,14 @@ module Backlogs
         order = Backlogs.setting[:sprint_sort_order] == 'desc' ? 'DESC' : 'ASC'
         (Backlogs.setting[:sharing_enabled] ? shared_releases : releases).
           visible.open.
-          order("#{RbRelease.table_name}.release_end_date #{order}, #{RbRelease.table_name}.release_start_date #{order}")
+          reorder("#{RbRelease.table_name}.release_end_date #{order}, #{RbRelease.table_name}.release_start_date #{order}")
       end
 
       def closed_releases_by_date
         order = Backlogs.setting[:sprint_sort_order] == 'desc' ? 'DESC' : 'ASC'
         (Backlogs.setting[:sharing_enabled] ? shared_releases : releases).
           visible.closed.
-          order("#{RbRelease.table_name}.release_end_date #{order}, #{RbRelease.table_name}.release_start_date #{order}")
+          reorder("#{RbRelease.table_name}.release_end_date #{order}, #{RbRelease.table_name}.release_start_date #{order}")
       end
 
       def shared_releases


### PR DESCRIPTION
The reorder method must be used instead of the order method to override the default ordering set by a has_many relation in Project.