### PR TITLE
Additional options for what to do with Tasks when copying a Story

### DIFF
--- a/app/views/backlogs/_settings.html.erb
+++ b/app/views/backlogs/_settings.html.erb
@@ -186,6 +186,17 @@
   <%= check_box_tag("settings[show_priority]", 'enabled',
       Backlogs.setting[:show_priority]) %>
 </p>
+
+<p>
+  <%= content_tag(:label, l(:backlogs_copy_tasks_default)) %>
+  <%= select_tag("settings[copy_tasks_default]",
+            options_for_select([
+                    [l(:rb_label_copy_tasks_open), 'open'],
+                    [l(:rb_label_copy_tasks_closed), 'closed'],
+                    [l(:rb_label_copy_tasks_none), 'none'],
+                    [l(:rb_label_copy_tasks_all), 'all']
+                ], Backlogs.setting[:copy_tasks_default])) %>
+</p>
 </fieldset>
 
 <fieldset>

--- a/app/views/backlogs/_settings.html.erb
+++ b/app/views/backlogs/_settings.html.erb
@@ -188,6 +188,15 @@
 </p>
 
 <p>
+  <%= content_tag(:label, l(:backlogs_copy_tasks_action)) %>
+  <%= select_tag("settings[copy_tasks_action]",
+            options_for_select([
+                    [l(:rb_label_copy_tasks_action_copy), 'copy'],
+                    [l(:rb_label_copy_tasks_action_move), 'move']
+            ], Backlogs.setting[:copy_tasks_action])) %>
+</p>
+
+<p>
   <%= content_tag(:label, l(:backlogs_copy_tasks_default)) %>
   <%= select_tag("settings[copy_tasks_default]",
             options_for_select([

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,7 @@ en:
   rb_label_copy_tasks_all: All
   rb_label_copy_tasks_none: None
   rb_label_copy_tasks_open: Open
+  rb_label_copy_tasks_closed: Closed
   rb_label_link_to_original: "Include link to original story"
   rb_label_timelog_disable: Disable
   rb_label_timelog_enable: Enable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,8 @@ en:
   backlogs_sharing_support: "Backlogs sharing"
   backlogs_show_in_scrum_stats: "Show project in Scrum statistics"
   backlogs_show_priority: "Show task priority on taskboard"
-  backlogs_copy_tasks_default: 'Default selection for "Copy tasks"'
+  backlogs_copy_tasks_action: "Copy or Move tasks when copying a Story"
+  backlogs_copy_tasks_default: 'Default selection for "Copy/Move tasks"'
   backlogs_show_redmine_std_header: "Show redmine header in backlogs"
   backlogs_show_stories_from_subprojects_in_backlog: "Show stories from subprojects in backlog"
   backlogs_sprint_card_settings: "Card printing"
@@ -185,7 +186,10 @@ en:
       To support distributed teams, calculations for burndown graphs use a common concept of when a day begins.
       Your user timezone is %{user_timezone}, the server timezone is %{server_timezone} and Burndowns use %{burndown_timezone} to calculate the graphs.
       Note: Historic data is not affected when changing this option.
+  rb_label_copy_tasks_action_copy: Copy
+  rb_label_copy_tasks_action_move: Move
   rb_label_copy_tasks: "Copy tasks"
+  rb_label_move_tasks: "Move tasks"
   rb_label_copy_tasks_all: All
   rb_label_copy_tasks_none: None
   rb_label_copy_tasks_open: Open

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
   backlogs_sharing_support: "Backlogs sharing"
   backlogs_show_in_scrum_stats: "Show project in Scrum statistics"
   backlogs_show_priority: "Show task priority on taskboard"
+  backlogs_copy_tasks_default: 'Default selection for "Copy tasks"'
   backlogs_show_redmine_std_header: "Show redmine header in backlogs"
   backlogs_show_stories_from_subprojects_in_backlog: "Show stories from subprojects in backlog"
   backlogs_sprint_card_settings: "Card printing"

--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -174,10 +174,10 @@ module BacklogsPlugin
             snippet += "#{check_box_tag('link_to_original', params[:copy_from], true)}</p>"
 
             snippet += "<p><label>#{l(:rb_label_copy_tasks)}</label>"
-            snippet += "#{radio_button_tag('copy_tasks', 'open:' + params[:copy_from], true)} #{l(:rb_label_copy_tasks_open)}<br />"
-            snippet += "#{radio_button_tag('copy_tasks', 'closed:' + params[:copy_from], false)} #{l(:rb_label_copy_tasks_closed)}<br />"
-            snippet += "#{radio_button_tag('copy_tasks', 'none', false)} #{l(:rb_label_copy_tasks_none)}<br />"
-            snippet += "#{radio_button_tag('copy_tasks', 'all:' + params[:copy_from], false)} #{l(:rb_label_copy_tasks_all)}</p>"
+            snippet += "#{radio_button_tag('copy_tasks', 'open:' + params[:copy_from], Backlogs.setting[:copy_tasks_default]=='open')} #{l(:rb_label_copy_tasks_open)}<br />"
+            snippet += "#{radio_button_tag('copy_tasks', 'closed:' + params[:copy_from], Backlogs.setting[:copy_tasks_default]=='closed')} #{l(:rb_label_copy_tasks_closed)}<br />"
+            snippet += "#{radio_button_tag('copy_tasks', 'none', Backlogs.setting[:copy_tasks_default]=='none')} #{l(:rb_label_copy_tasks_none)}<br />"
+            snippet += "#{radio_button_tag('copy_tasks', 'all:' + params[:copy_from], Backlogs.setting[:copy_tasks_default]=='all')} #{l(:rb_label_copy_tasks_all)}</p>"
           end
 
           if issue.is_task? && !issue.new_record?

--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -175,6 +175,7 @@ module BacklogsPlugin
 
             snippet += "<p><label>#{l(:rb_label_copy_tasks)}</label>"
             snippet += "#{radio_button_tag('copy_tasks', 'open:' + params[:copy_from], true)} #{l(:rb_label_copy_tasks_open)}<br />"
+            snippet += "#{radio_button_tag('copy_tasks', 'closed:' + params[:copy_from], false)} #{l(:rb_label_copy_tasks_closed)}<br />"
             snippet += "#{radio_button_tag('copy_tasks', 'none', false)} #{l(:rb_label_copy_tasks_none)}<br />"
             snippet += "#{radio_button_tag('copy_tasks', 'all:' + params[:copy_from], false)} #{l(:rb_label_copy_tasks_all)}</p>"
           end
@@ -338,6 +339,8 @@ module BacklogsPlugin
               case action
                 when 'open'
                   tasks = story.tasks.select{|t| !t.reload.closed?}
+                when 'closed'
+                  tasks = story.tasks.reject{|t| !t.reload.closed?}
                 when 'none'
                   tasks = []
                 when 'all'
@@ -353,6 +356,9 @@ module BacklogsPlugin
                 nt.position = nil # will assign a new position
                 nt.save!
               }
+
+              # In case the new story only has closed tasks, make sure it is closed.
+              context[:issue].becomes(RbStory).story_follow_task_state
             end
           end
         end


### PR DESCRIPTION
- [X] Add "Closed" option to the "Copy Tasks" choice
- [X] Add Setting for default-selected option in "Copy Tasks" choice
- [X] Add Setting to Move tasks instead of Copying them