### PR TITLE
Fix: View issue from closed project.

### DIFF
--- a/lib/backlogs_project_patch.rb
+++ b/lib/backlogs_project_patch.rb
@@ -94,7 +94,7 @@ module Backlogs
     end
 
     def test_product_backlog_sized
-      return !@product_backlog.detect{|s| s.story_points.blank? }
+      return (@project.status != Project::STATUS_ACTIVE || !@product_backlog.detect{|s| s.story_points.blank? })
     end
 
     def test_sprints_sized


### PR DESCRIPTION
Fix: Error viewing issues of closed project when sharing backlogs is enabled in config.

When sharing backlogs is enabled in config and the project is closed, product_backlog gets an sql error due to the project being filtered out.