### PR TITLE
Using div.splitpanel against th-td on issues show bottom details view hook when rendering plugin related fileds - redmine 3 compatibility

### DIFF
--- a/app/views/hooks/_view_issues_show_details_bottom.erb
+++ b/app/views/hooks/_view_issues_show_details_bottom.erb
@@ -1,0 +1,33 @@
+<%=
+  begin
+    if Backlogs.configured?(issue.project)
+      issue_fields_rows do |rows|
+        if issue.is_story?
+          rows.left l(:field_story_points), RbStory.find(issue.id).points_display, :class => 'story-points'
+
+          unless issue.remaining_hours.nil?
+            rows.left l(:field_remaining_hours), l_hours(issue.remaining_hours), :class => 'remaining-hours'
+          end
+
+          rows.left l(:field_velocity_based_estimate), issue.velocity_based_estimate ? issue.velocity_based_estimate.to_s + ' days' : '', :class => 'velocity-based-estimate'
+
+          unless issue.release_id.nil?
+            release = RbRelease.find(issue.release_id)
+            link_to_release = link_to(release.name, url_for_prefix_in_hooks + url_for({:controller => 'rb_releases', :action => 'show', :release_id => release}))
+            relation_translate = l("label_release_relationship_#{RbStory.find(issue.id).release_relationship}")
+            rows.right l(:field_release), link_to_release, :class => 'release'
+            rows.right l(:field_release_relationship), relation_translate, :class => 'release-relationship'
+          end
+        end
+
+        if issue.is_task? && User.current.allowed_to?(:update_remaining_hours, project) != nil
+          rows.left l(:field_remaining_hours), issue.remaining_hours, :class => 'remaining-hours'
+        end
+      end
+    end
+  rescue => e
+    controller.send(:flash)[:error] = "Backlogs error: #{e.message} (#{e.class})"
+    Rails.logger.error "#{e.message} (#{e.class}): " + e.backtrace.join("\n")
+    ''
+  end
+%>

--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -80,43 +80,8 @@ module BacklogsPlugin
         end
       end
 
-      def view_issues_show_details_bottom(context={ })
-        begin
-          issue = context[:issue]
+      render_on :view_issues_show_details_bottom, :partial => 'hooks/view_issues_show_details_bottom'
 
-          return '' unless Backlogs.configured?(issue.project)
-
-          snippet = ''
-
-          project = context[:project]
-
-          if issue.is_story?
-            snippet += "<tr><th>#{l(:field_story_points)}</th><td>#{RbStory.find(issue.id).points_display}</td>"
-            unless issue.remaining_hours.nil?
-              snippet += "<th>#{l(:field_remaining_hours)}</th><td>#{l_hours(issue.remaining_hours)}</td>"
-            end
-            snippet += "</tr>"
-            vbe = issue.velocity_based_estimate
-            snippet += "<tr><th>#{l(:field_velocity_based_estimate)}</th><td>#{vbe ? vbe.to_s + ' days' : '-'}</td></tr>"
-
-            unless issue.release_id.nil?
-              release = RbRelease.find(issue.release_id)
-              snippet += "<tr><th>#{l(:field_release)}</th><td>#{link_to(release.name, url_for_prefix_in_hooks + url_for({:controller => 'rb_releases', :action => 'show', :release_id => release}))}</td>"
-              relation_translate = l("label_release_relationship_#{RbStory.find(issue.id).release_relationship}")
-              snippet += "<th>#{l(:field_release_relationship)}</th><td>#{relation_translate}</td></tr>"
-            end
-          end
-
-          if issue.is_task? && User.current.allowed_to?(:update_remaining_hours, project) != nil
-            snippet += "<tr><th>#{l(:field_remaining_hours)}</th><td>#{issue.remaining_hours}</td></tr>"
-          end
-
-          return snippet
-        rescue => e
-          exception(context, e)
-          return ''
-        end
-      end
 
       def view_issues_form_details_bottom(context={ })
         begin


### PR DESCRIPTION
Hi!

There was a problem on the issue view. When rendering the backlogs plugin related fields on the bottom of the details section, the plugin used th and td elements, but the new redmine 3.3 style is div elements with splitpanel class. Because of that the fields didn't render properly.

I changed your view hook in that way that is uses the redmine's IssueHelper.issue_fields_rows method to render these fields so they are fit into the new layout.

Because of the new layout based on left and rigth columns and the old layout based on table row elements, it was necessary to reorder these fields a bit.