### PR TITLE
Semantically correct version number

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -52,7 +52,7 @@ Redmine::Plugin.register :redmine_backlogs do
   name 'Redmine Backlogs'
   author "friflaj,Mark Maglana,John Yani,mikoto20000,Frank Blendinger,Bo Hansen,stevel,Patrick Atamaniuk"
   description 'A plugin for agile teams'
-  version 'v1.0.6'
+  version '1.0.6'
 
   settings :default => {
                          :story_trackers            => nil,


### PR DESCRIPTION
When I create some plugin that depends on Backlogs, with using "requires_remine_plugin", because of the "v" prefixing the version number, "version_or_higher" doesn't works. That's why simply removing the "v"

Ref : http://www.rubydoc.info/github/asoltys/redmine/Redmine/Plugin#requires_redmine_plugin-instance_method